### PR TITLE
Coldfront internal update

### DIFF
--- a/coldfront/components/site/templates/allocation/allocation_detail.html
+++ b/coldfront/components/site/templates/allocation/allocation_detail.html
@@ -103,89 +103,33 @@ Allocation Detail
                 {% else %}
                   {{ allocation.end_date }}
                 {% endif %}
-                {% if allocation.get_parent_resource.requires_payment %}
+                {% if allocation.project.requires_review %}
                   {% if allocation.is_locked and allocation.status.name == 'Active' and allocation.expires_in <= ALLOCATION_DAYS_TO_REVIEW_BEFORE_EXPIRING and allocation.expires_in >= 0 %}
                     <span class="badge badge-warning"><i class="far fa-clock" aria-hidden="true"></i>
-                      Expires in {{allocation.expires_in}} day{{allocation.expires_in|pluralize}} <br> Not renewable
+                      Expires in {{allocation.expires_in}} day{{allocation.expires_in|pluralize}} - Not renewable
                     </span>
                   {% elif is_allowed_to_update_project and ALLOCATION_ENABLE_ALLOCATION_RENEWAL and allocation.status.name == 'Active' and allocation.expires_in <= ALLOCATION_DAYS_TO_REVIEW_BEFORE_EXPIRING and allocation.expires_in >= 0 %}
-                    {% if project.can_be_reviewed and project.status.name != 'Expired' %}
-                      <span class="badge badge-warning">
-                        Expires in {{ allocation.expires_in }} day{{ allocation.expires_in|pluralize }} <br> Cannot renew until <br> project is reviewed
+                    <a href="{% url 'allocation-renew' allocation.pk %}">
+                      <span class="badge badge-warning"><i class="fas fa-redo-alt" aria-hidden="true"></i>
+                        Expires in {{allocation.expires_in}} day{{allocation.expires_in|pluralize}}
+                        {% if allocation.can_be_renewed %} - Click to renew {% endif %}
                       </span>
-                    {% elif project.status.name ==  'Review Pending' %}
-                      <span class="badge badge-warning">
-                        Expires in {{ allocation.expires_in }} day{{ allocation.expires_in|pluralize }} <br> Cannot renew during <br> project review
-                      </span>
-                    {% elif project.status.name in 'Expired, Denied' %}
-                      <span class="badge badge-warning">
-                        Expires in {{ allocation.expires_in }} day{{ allocation.expires_in|pluralize }}
-                      </span>
-                    {% else %}
-                      <a href="{% url 'allocation-renew' allocation.pk %}">
+                    </a>
+                  {% elif is_allowed_to_update_project and ALLOCATION_ENABLE_ALLOCATION_RENEWAL and allocation.status.name == 'Expired' and ALLOCATION_DAYS_TO_REVIEW_AFTER_EXPIRING < 0  %}
+                    <a href="{% url 'allocation-renew' allocation.pk %}">
+                      {% if allocation.can_be_renewed %}
                         <span class="badge badge-warning"><i class="fas fa-redo-alt" aria-hidden="true"></i>
-                        Expires in {{allocation.expires_in}} day{{allocation.expires_in|pluralize}} <br> Click to renew
+                          Click to renew 
                         </span>
-                      </a>
-                    {% endif %}
+                      {% endif %}
+                    </a>
                   {% elif is_allowed_to_update_project and ALLOCATION_ENABLE_ALLOCATION_RENEWAL and allocation.status.name == 'Expired' and allocation.expires_in >= ALLOCATION_DAYS_TO_REVIEW_AFTER_EXPIRING|change_sign %}
-                    {% if project.can_be_reviewed and project.status.name != 'Expired' %}
-                      <span class="badge badge-warning">
-                        {{ allocation.expires_in|add:ALLOCATION_DAYS_TO_REVIEW_AFTER_EXPIRING }} days left to renew <br> Cannot renew until <br> project is reviewed
+                    <a href="{% url 'allocation-renew' allocation.pk %}">
+                      <span class="badge badge-warning"><i class="fas fa-redo-alt" aria-hidden="true"></i>
+                        {{ allocation.expires_in|add:ALLOCATION_DAYS_TO_REVIEW_AFTER_EXPIRING }} days left to renew
+                        {% if allocation.can_be_renewed %} Click to renew {% endif %}
                       </span>
-                    {% elif project.status.name ==  'Review Pending' %}
-                      <span class="badge badge-warning">
-                        {{ allocation.expires_in|add:ALLOCATION_DAYS_TO_REVIEW_AFTER_EXPIRING }} days left to renew <br> Cannot renew during <br> project review
-                      </span>
-                    {% elif project.status.name not in 'Expired, Denied, Revoked, Removed' %}
-                      <a href="{% url 'allocation-renew' allocation.pk %}">
-                          <span class="badge badge-warning"><i class="fas fa-redo-alt" aria-hidden="true"></i>
-                            {{ allocation.expires_in|add:ALLOCATION_DAYS_TO_REVIEW_AFTER_EXPIRING }} days left to renew
-                          </span>
-                        </a>
-                    {% endif %}
-                  {% endif %}
-                {% else %}
-                  {% if allocation.is_locked and allocation.status.name == 'Active' and allocation.expires_in <= ALLOCATION_DAYS_TO_REVIEW_BEFORE_EXPIRING and allocation.expires_in >= 0 %}
-                    <span class="badge badge-warning">
-                      Expires in {{allocation.expires_in}} day{{allocation.expires_in|pluralize}} <br> Not renewable
-                    </span>
-                  {% elif is_allowed_to_update_project and ALLOCATION_ENABLE_ALLOCATION_RENEWAL and allocation.status.name == 'Active' and allocation.expires_in <= ALLOCATION_DAYS_TO_REVIEW_BEFORE_EXPIRING and allocation.expires_in >= 0 %}
-                    {% if project.can_be_reviewed and project.status.name != 'Expired' %}
-                      <span class="badge badge-warning">
-                        Expires in {{ allocation.expires_in }} day{{ allocation.expires_in|pluralize }} <br> Renew in project review
-                      </span>
-                    {% elif project.status.name ==  'Review Pending' %}
-                      <span class="badge badge-warning">
-                        Expires in {{ allocation.expires_in }} day{{ allocation.expires_in|pluralize }} <br> Cannot renew during <br> project review
-                      </span>
-                    {% elif project.status.name in 'Expired, Denied' %}
-                      <span class="badge badge-warning">
-                        Expires in {{ allocation.expires_in }} day{{ allocation.expires_in|pluralize }}
-                      </span>
-                    {% else %}
-                      <a href="{% url 'allocation-renew' allocation.pk %}">
-                        <span class="badge badge-warning"><i class="fas fa-redo-alt" aria-hidden="true"></i>
-                        Expires in {{allocation.expires_in}} day{{allocation.expires_in|pluralize}} <br> Click to renew
-                        </span>
-                      </a>
-                    {% endif %}
-                  {% elif is_allowed_to_update_project and ALLOCATION_ENABLE_ALLOCATION_RENEWAL and allocation.status.name == 'Expired' and allocation.expires_in >= ALLOCATION_DAYS_TO_REVIEW_AFTER_EXPIRING|change_sign %}
-                    {% if project.can_be_reviewed and project.status.name != 'Expired' %}
-                      <span class="badge badge-warning">
-                        {{ allocation.expires_in|add:ALLOCATION_DAYS_TO_REVIEW_AFTER_EXPIRING }} days left to renew <br> Renew in project review
-                      </span>
-                    {% elif project.status.name == 'Review Pending' %}
-                      <span class="badge badge-warning">
-                        {{ allocation.expires_in|add:ALLOCATION_DAYS_TO_REVIEW_AFTER_EXPIRING }} days left to renew <br> Cannot renew during <br> project review
-                      </span>
-                    {% elif project.status.name not in 'Expired, Denied, Revoked, Removed' %}
-                      <a href="{% url 'allocation-renew' allocation.pk %}">
-                        <span class="badge badge-warning"><i class="fas fa-redo-alt" aria-hidden="true"></i>
-                          {{ allocation.expires_in|add:ALLOCATION_DAYS_TO_REVIEW_AFTER_EXPIRING }} days left to renew
-                        </span>
-                      </a>
-                    {% endif %}
+                    </a>
                   {% endif %}
                 {% endif %}
               </td>

--- a/coldfront/components/site/templates/project/project_detail.html
+++ b/coldfront/components/site/templates/project/project_detail.html
@@ -310,51 +310,34 @@ Project Detail
                 <a title="Details" href="{% url 'allocation-detail' allocation.pk %}">
                   <i class="far fa-folder-open" aria-hidden="true"></i><span class="sr-only">Details</span>
                 </a>
-                {% if project.requires_review %}
+                {% if allocation.project.requires_review %}
                   {% if allocation.is_locked and allocation.status.name == 'Active' and allocation.expires_in <= ALLOCATION_DAYS_TO_REVIEW_BEFORE_EXPIRING and allocation.expires_in >= 0 %}
                     <span class="badge badge-warning"><i class="far fa-clock" aria-hidden="true"></i>
-                      Expires in {{allocation.expires_in}} day{{allocation.expires_in|pluralize}} <br> Not renewable
+                      Expires in {{allocation.expires_in}} day{{allocation.expires_in|pluralize}} - Not renewable
                     </span>
                   {% elif is_allowed_to_update_project and ALLOCATION_ENABLE_ALLOCATION_RENEWAL and allocation.status.name == 'Active' and allocation.expires_in <= ALLOCATION_DAYS_TO_REVIEW_BEFORE_EXPIRING and allocation.expires_in >= 0 %}
-                    {% if project.can_be_reviewed and project.status.name != 'Expired' %}
-                      <span class="badge badge-warning">
-                        Expires in {{ allocation.expires_in }} day{{ allocation.expires_in|pluralize }} <br> Renew in project review
+                    <a href="{% url 'allocation-renew' allocation.pk %}">
+                      <span class="badge badge-warning"><i class="fas fa-redo-alt" aria-hidden="true"></i>
+                        Expires in {{allocation.expires_in}} day{{allocation.expires_in|pluralize}}
+                        {% if allocation.can_be_renewed %} - Click to renew {% endif %}
                       </span>
-                    {% elif project.status.name ==  'Review Pending' %}
-                      <span class="badge badge-warning">
-                        Expires in {{ allocation.expires_in }} day{{ allocation.expires_in|pluralize }} <br> Cannot renew during <br> project review
-                      </span>
-                    {% elif project.status.name in 'Expired, Denied' %}
-                      <span class="badge badge-warning">
-                        Expires in {{ allocation.expires_in }} day{{ allocation.expires_in|pluralize }}
-                      </span>
-                    {% else %}
-                      <a href="{% url 'allocation-renew' allocation.pk %}">
+                    </a>
+                  {% elif is_allowed_to_update_project and ALLOCATION_ENABLE_ALLOCATION_RENEWAL and allocation.status.name == 'Expired' and ALLOCATION_DAYS_TO_REVIEW_AFTER_EXPIRING < 0  %}
+                    <a href="{% url 'allocation-renew' allocation.pk %}">
+                      {% if allocation.can_be_renewed %}
                         <span class="badge badge-warning"><i class="fas fa-redo-alt" aria-hidden="true"></i>
-                        Expires in {{allocation.expires_in}} day{{allocation.expires_in|pluralize}} <br> Click to renew
+                          Click to renew 
                         </span>
-                      </a>
-                    {% endif %}
-                  {% endif %}
-                {% elif is_allowed_to_update_project and ALLOCATION_ENABLE_ALLOCATION_RENEWAL and allocation.status.name == 'Expired' and allocation.expires_in > ALLOCATION_DAYS_TO_REVIEW_AFTER_EXPIRING|change_sign %}
-                  {% if project.can_be_reviewed and project.status.name != 'Expired' %}
-                    <span class="badge badge-warning">
-                      {{ allocation.expires_in|add:ALLOCATION_DAYS_TO_REVIEW_AFTER_EXPIRING }} days left to renew <br> Renew in project review
-                    </span>
-                  {% elif project.status.name == 'Review Pending' %}
-                    <span class="badge badge-warning">
-                      {{ allocation.expires_in|add:ALLOCATION_DAYS_TO_REVIEW_AFTER_EXPIRING }} days left to renew <br> Cannot renew during <br> project review
-                    </span>
-                  {% elif project.status.name not in 'Expired, Denied' %}
+                      {% endif %}
+                    </a>
+                  {% elif is_allowed_to_update_project and ALLOCATION_ENABLE_ALLOCATION_RENEWAL and allocation.status.name == 'Expired' and allocation.expires_in >= ALLOCATION_DAYS_TO_REVIEW_AFTER_EXPIRING|change_sign %}
                     <a href="{% url 'allocation-renew' allocation.pk %}">
                       <span class="badge badge-warning"><i class="fas fa-redo-alt" aria-hidden="true"></i>
                         {{ allocation.expires_in|add:ALLOCATION_DAYS_TO_REVIEW_AFTER_EXPIRING }} days left to renew
+                        {% if allocation.can_be_renewed %} - Click to renew {% endif %}
                       </span>
                     </a>
                   {% endif %}
-                {% endif %}
-                {% if allocation.get_parent_resource.get_ondemand_status == 'Yes' and ondemand_url %}
-                  <a href = "{{ ondemand_url }}" target="_blank"> <img src="/static/core/portal/imgs/ondemand.png" alt="ondemand cta" width="25" height="25"></a>
                 {% endif %}
               </td>
             </tr>
@@ -401,55 +384,35 @@ Project Detail
                 <a href="{% url 'allocation-detail' allocation.pk %}">
                   <i title="Details" class="far fa-folder-open" aria-hidden="true"></i><span class="sr-only">Details</span>
                 </a>
-                {% if is_allowed_to_update_project and allocation.status.name in 'Active, Billing Information Submitted' %}
-                  <a href="{% url 'allocation-remove' pk=allocation.pk %}?from_project=true">
-                    <i title="Remove access" class="far fa-times-circle" aria-hidden="true"></i><span class="sr-only">Remove access</span>
-                  </a>
-                {% endif %}
-                {% if allocation.is_locked and allocation.status.name == 'Active' and allocation.expires_in <= ALLOCATION_DAYS_TO_REVIEW_BEFORE_EXPIRING and allocation.expires_in >= 0 %}
-                  <span class="badge badge-warning"><i class="far fa-clock" aria-hidden="true"></i>
-                    Expires in {{allocation.expires_in}} day{{allocation.expires_in|pluralize}} <br> Not renewable
-                  </span>
-                {% elif is_allowed_to_update_project and ALLOCATION_ENABLE_ALLOCATION_RENEWAL and allocation.status.name == 'Active' and allocation.expires_in <= ALLOCATION_DAYS_TO_REVIEW_BEFORE_EXPIRING and allocation.expires_in >= 0 %}
-                  {% if project.can_be_reviewed and project.status.name != 'Expired' %}
-                    <span class="badge badge-warning">
-                      Expires in {{ allocation.expires_in }} day{{ allocation.expires_in|pluralize }} <br> Cannot renew until <br> project is reviewed
+                {% if allocation.project.requires_review %}
+                  {% if allocation.is_locked and allocation.status.name == 'Active' and allocation.expires_in <= ALLOCATION_DAYS_TO_REVIEW_BEFORE_EXPIRING and allocation.expires_in >= 0 %}
+                    <span class="badge badge-warning"><i class="far fa-clock" aria-hidden="true"></i>
+                      Expires in {{allocation.expires_in}} day{{allocation.expires_in|pluralize}} - Not renewable
                     </span>
-                  {% elif project.status.name ==  'Review Pending' %}
-                    <span class="badge badge-warning">
-                      Expires in {{ allocation.expires_in }} day{{ allocation.expires_in|pluralize }} <br> Cannot renew during <br> project review
-                    </span>
-                  {% elif project.status.name in 'Expired, Denied' %}
-                    <span class="badge badge-warning">
-                      Expires in {{ allocation.expires_in }} day{{ allocation.expires_in|pluralize }}
-                    </span>
-                  {% else %}
+                  {% elif is_allowed_to_update_project and ALLOCATION_ENABLE_ALLOCATION_RENEWAL and allocation.status.name == 'Active' and allocation.expires_in <= ALLOCATION_DAYS_TO_REVIEW_BEFORE_EXPIRING and allocation.expires_in >= 0 %}
                     <a href="{% url 'allocation-renew' allocation.pk %}">
                       <span class="badge badge-warning"><i class="fas fa-redo-alt" aria-hidden="true"></i>
-                      Expires in {{allocation.expires_in}} day{{allocation.expires_in|pluralize}} <br> Click to renew
+                        Expires in {{allocation.expires_in}} day{{allocation.expires_in|pluralize}}
+                        {% if allocation.can_be_renewed %} - Click to renew {% endif %}
                       </span>
                     </a>
-                  {% endif %}
-                {% elif is_allowed_to_update_project and ALLOCATION_ENABLE_ALLOCATION_RENEWAL and allocation.status.name == 'Expired' and allocation.expires_in > ALLOCATION_DAYS_TO_REVIEW_AFTER_EXPIRING|change_sign %}
-                  {% if project.can_be_reviewed and project.status.name != 'Expired' %}
-                    <span class="badge badge-warning">
-                      {{ allocation.expires_in|add:ALLOCATION_DAYS_TO_REVIEW_AFTER_EXPIRING }} days left to renew <br> Cannot renew until <br> project is reviewed
-                    </span>
-                  {% elif project.status.name ==  'Review Pending' %}
-                    <span class="badge badge-warning">
-                      {{ allocation.expires_in|add:ALLOCATION_DAYS_TO_REVIEW_AFTER_EXPIRING }} days left to renew <br> Cannot renew during <br> project review
-                    </span>
-                  {% elif project.status.name not in 'Expired, Denied' %}
+                  {% elif is_allowed_to_update_project and ALLOCATION_ENABLE_ALLOCATION_RENEWAL and allocation.status.name == 'Expired' and ALLOCATION_DAYS_TO_REVIEW_AFTER_EXPIRING < 0  %}
+                    <a href="{% url 'allocation-renew' allocation.pk %}">
+                      {% if allocation.can_be_renewed %}
+                        <span class="badge badge-warning"><i class="fas fa-redo-alt" aria-hidden="true"></i>
+                          Click to renew 
+                        </span>
+                      {% endif %}
+                    </a>
+                  {% elif is_allowed_to_update_project and ALLOCATION_ENABLE_ALLOCATION_RENEWAL and allocation.status.name == 'Expired' and allocation.expires_in >= ALLOCATION_DAYS_TO_REVIEW_AFTER_EXPIRING|change_sign %}
                     <a href="{% url 'allocation-renew' allocation.pk %}">
                       <span class="badge badge-warning"><i class="fas fa-redo-alt" aria-hidden="true"></i>
                         {{ allocation.expires_in|add:ALLOCATION_DAYS_TO_REVIEW_AFTER_EXPIRING }} days left to renew
+                        {% if allocation.can_be_renewed %} - Click to renew {% endif %}
                       </span>
                     </a>
                   {% endif %}
                 {% endif %}
-                {% if allocation.get_parent_resource.get_ondemand_status == 'Yes' and ondemand_url %}
-                  <a href="{{ ondemand_url }}" target="_blank"> <img src="/static/core/portal/imgs/ondemand.png" alt="ondemand cta" width="25" height="25"></a>
-                {% endif %}  
               </td>
             </tr>
           {% endfor %}

--- a/coldfront/core/project/views.py
+++ b/coldfront/core/project/views.py
@@ -1918,7 +1918,7 @@ class ProjectReviewView(LoginRequiredMixin, UserPassesTestMixin, TemplateView):
             for allocation in allocations:
                 if allocation.end_date is None:
                     continue
-                if allocation.expires_in < -ALLOCATION_DAYS_TO_REVIEW_AFTER_EXPIRING:
+                if ALLOCATION_DAYS_TO_REVIEW_AFTER_EXPIRING >= 0 and allocation.expires_in < -ALLOCATION_DAYS_TO_REVIEW_AFTER_EXPIRING:
                     continue
 
                 data = {

--- a/coldfront/core/utils/management/commands/backfill_allocation_attributes.py
+++ b/coldfront/core/utils/management/commands/backfill_allocation_attributes.py
@@ -1,0 +1,71 @@
+from coldfront.core.allocation.models import AllocationAttribute, AllocationAttributeType, Allocation
+from coldfront.core.resource.models import Resource
+
+from django.core.management.base import BaseCommand
+
+
+class Command(BaseCommand):
+    def add_arguments(self, parser):
+        parser.add_argument(
+            '-at',
+            '--allocation_attribute_type',
+            help='Allocation attribute type the new allocation attribute should have',
+            required=True
+        )
+        parser.add_argument(
+            '-ia',
+            '--internal_allocation_attribute',
+            help='Allocation attribute within the allocation class whose value we need',
+            required=True
+        )
+        parser.add_argument(
+            '-r',
+            '--resource',
+            help='Allocations containing this resource that should be backfilled',
+            required=True
+        )
+
+    def handle(self, *args, **options):
+        allocation_attribute_type = options.get('allocation_attribute_type')
+        internal_allocation_attribute = options.get('internal_allocation_attribute')
+        resource = options.get('resource')
+
+        resource_obj = Resource.objects.filter(name=resource)
+        if not resource_obj.exists():
+            print('This resource does not exist')
+            return
+        resource_obj = resource_obj[0]
+
+        allocation_attribute_type_obj = AllocationAttributeType.objects.filter(name=allocation_attribute_type)
+        if not allocation_attribute_type_obj.exists():
+            print('This allocation attribute type does not exist')
+            return
+        allocation_attribute_type_obj = allocation_attribute_type_obj[0]
+
+        if resource_obj not in allocation_attribute_type_obj.get_linked_resources():
+            print('This resource is not linked to this allocation attribute type')
+            return
+        
+        if not hasattr(Allocation, internal_allocation_attribute):
+            print('This internal allocation attribute does not exist')
+            return
+
+        count = 0
+        allocation_objs = Allocation.objects.filter(resources = resource_obj)
+        for allocation_obj in allocation_objs:
+            value = getattr(allocation_obj, internal_allocation_attribute)
+            allocation_attribute_exists = AllocationAttribute.objects.filter(
+                allocation_attribute_type=allocation_attribute_type_obj, allocation=allocation_obj
+            ).exists()
+            if allocation_attribute_exists or not value:
+                continue
+
+            AllocationAttribute.objects.create(
+                allocation=allocation_obj,
+                allocation_attribute_type=allocation_attribute_type_obj,
+                value=value
+            )
+
+            count += 1
+
+        print(f'Created {count} allocation attributes')


### PR DESCRIPTION
Changes:
- Stop showing renewal warnings for allocations in a project that doesn't need to be renewed
- Create option to always allow renewing allocations after expiring
- Add command to backfill missing allocation attributes