### PR TITLE
Coldfront internal update

### DIFF
--- a/coldfront/components/site/templates/allocation/allocation_removal_request_list.html
+++ b/coldfront/components/site/templates/allocation/allocation_removal_request_list.html
@@ -18,7 +18,7 @@ Allocation Review Pending Removal Requests
   For each allocation removal request below, there is the option to approve the allocation removal request and to view the allocation's detail page.
 </p>
 
-{% if allocation_list %}
+{% if allocation_removal_list %}
   <div class="table-responsive">
     <table class="table table-sm">
       <thead>
@@ -26,25 +26,32 @@ Allocation Review Pending Removal Requests
           <th scope="col">#</th>
           <th scope="col">Project Title</th>
           <th scope="col">PI</th>
+          <th scope="col">Requestor</th>
           <th scope="col">Resource</th>
-          <th scope="col">Status</th>
           <th scope="col">Actions</th>
         </tr>
       </thead>
       <tbody>
-        {% for allocation in allocation_list %}
+        {% for allocation_removal in allocation_removal_list %}
           <tr>
-            <td>{{ allocation.pk }}</td>
-            <td><a href="{% url 'project-detail' allocation.project.pk %}">{{allocation.project.title|truncatechars:50}}</a></td>
+            <td>{{ allocation_removal.pk }}</td>
             <td>
-              {{allocation.project.pi.first_name}} {{allocation.project.pi.last_name}}
-              ({{allocation.project.pi.username}})
+              <a href="{% url 'project-detail' allocation_removal.allocation.project.pk %}">
+                {{allocation_removal.allocation.project.title|truncatechars:50}}
+              </a>
             </td>
-            <td>{{allocation.get_parent_resource}}</td>
-            <td>{{allocation.status}}</td>
+            <td>
+              {{allocation_removal.project_pi.first_name}} {{allocation_removal.project_pi.last_name}}
+              ({{allocation_removal.project_pi.username}})
+            </td>
+            <td>
+              {{allocation_removal.requestor.first_name}} {{allocation_removal.requestor.last_name}}
+              ({{allocation_removal.requestor.username}})
+            </td>
+            <td>{{allocation_removal.allocation.get_parent_resource}}</td>
             <td class="text-nowrap">
-              <a href="{% url 'allocation-approve-removal-request' allocation.pk %}" class="btn btn-success mr-1">Approve</a>
-              <a href="{% url 'allocation-deny-removal-request' allocation.pk %}" class="btn btn-danger mr-1">Deny</a>
+              <a href="{% url 'allocation-approve-removal-request' allocation_removal.pk %}" class="btn btn-success mr-1">Approve</a>
+              <a href="{% url 'allocation-deny-removal-request' allocation_removal.pk %}" class="btn btn-danger mr-1">Deny</a>
             </td>
           </tr>
         {% endfor %}

--- a/coldfront/components/site/templates/email/new_allocation_request.txt
+++ b/coldfront/components/site/templates/email/new_allocation_request.txt
@@ -1,2 +1,2 @@
 A new allocation in project "{{project_title}}" with id {{project_id}} has been requested for {{pi}} - {{resource}}. Please review the allocation:
-{{url}}
+{{url}}. Project detail url: {{project_detail_url}}

--- a/coldfront/components/site/templates/portal/allocation_summary.html
+++ b/coldfront/components/site/templates/portal/allocation_summary.html
@@ -31,13 +31,13 @@
   $(document).ready(function () {
     drawAllocations();
     drawResources();
-    $('#resource-table').DataTable({
-      "iDisplayLength": 10,
-      "bSortClasses": false,
-      "order": [
-        [1, "desc"]
-      ]
-    });
+    // $('#resource-table').DataTable({
+    //   "iDisplayLength": 10,
+    //   "bSortClasses": false,
+    //   "order": [
+    //     [1, "desc"]
+    //   ]
+    // });
   });
 
   function drawAllocations() {

--- a/coldfront/components/site/templates/portal/center_summary.html
+++ b/coldfront/components/site/templates/portal/center_summary.html
@@ -11,7 +11,7 @@ Center Summary
 
 
 {% block content %}
-<h2>{% settings_value 'CENTER_NAME' %} Scientific Impact</h2>
+<!-- <h2>{% settings_value 'CENTER_NAME' %} Scientific Impact</h2> -->
 <hr>
 
 <!-- Start Tableau Dashboards -->

--- a/coldfront/components/site/templates/portal/project_summary.html
+++ b/coldfront/components/site/templates/portal/project_summary.html
@@ -4,84 +4,28 @@
     <div id="projectTypes" style="min-height: 270px;"></div>
   </div>
   <div class="col">
-    <div id="projectStatuses" style="min-height: 270px;"></div>
+    <div id="projectUsers" style="min-height: 270px;"></div>
   </div>
 </div>
 
 <script>
   var project_type_chart_data = {{ project_type_chart_data | safe }}
-  var project_status_chart_data = {{ project_status_chart_data | safe }}
-  var research_project_status_columns = {{ research_project_status_columns | safe }}
-  var class_project_status_columns = {{ class_project_status_columns | safe }}
-
-  var typeChart;
-  var statusesChart;
-  let currentlyLoadedProjectTypeColumns = [...project_type_chart_data['columns']]
-  let currentlyLoadedProjectStatusesColumns = [...project_status_chart_data['columns']]
+  var project_user_chart_data = {{ project_user_chart_data | safe }}
 
   $(document).ready(function () {
-    typeChart = drawProjectTypes();
-    statusesChart = drawProjectStatuses();
+    drawProjectTypes();
+    drawProjectUsers();
   });
-
-  function resetProjectGraphs() {
-    typeChart.load({columns: project_type_chart_data['columns']});
-    currentlyLoadedProjectTypeColumns = [...project_type_chart_data['columns']];
-
-    var columnsToUnload = [];
-    for (var i = 0; i < currentlyLoadedProjectStatusesColumns.length; i++) {
-      columnsToUnload.push(currentlyLoadedProjectStatusesColumns[i][0]);
-    }
-    currentlyLoadedProjectStatusesColumns = [];
-    statusesChart.load({
-      unload: columnsToUnload,
-      columns: project_status_chart_data['columns']
-    });
-    currentlyLoadedProjectStatusesColumns = [...project_status_chart_data['columns']];
-  }
 
   function drawProjectTypes() {
     data = {
       columns: project_type_chart_data['columns'],
       type: project_type_chart_data['type'],
       colors: project_type_chart_data['colors'],
-      onclick: function(obj) {
-        if (currentlyLoadedProjectTypeColumns.length === 1) {
-          resetProjectGraphs(currentlyLoadedProjectStatusesColumns, currentlyLoadedProjectStatusesColumns)
-          return;
-        }
-        var columnsToUnload = [];
-        for (var i = 0; i < currentlyLoadedProjectTypeColumns.length; i++) {
-          if (currentlyLoadedProjectTypeColumns[i][0] !== obj.id) {
-            columnsToUnload.push(currentlyLoadedProjectTypeColumns[i][0]);
-            currentlyLoadedProjectTypeColumns.splice(currentlyLoadedProjectTypeColumns.indexOf(currentlyLoadedProjectTypeColumns[i][0]));
-          }
-        }
-        typeChart.unload({ids: columnsToUnload})
-
-        var columnsToUnload = [];
-        for (var i = 0; i < currentlyLoadedProjectStatusesColumns.length; i++) {
-          columnsToUnload.push(currentlyLoadedProjectStatusesColumns[i][0]);
-        }
-        currentlyLoadedProjectStatusesColumns = [];
-        if (obj.id.split(':')[0] === 'Research') {
-          currentlyLoadedProjectStatusesColumns = [...research_project_status_columns['columns']];
-          statusesChart.load({
-            unload: columnsToUnload,
-            columns: research_project_status_columns['columns']
-          });
-        } else {
-          currentlyLoadedProjectStatusesColumns = [...class_project_status_columns['columns']];
-          statusesChart.load({
-            unload: columnsToUnload,
-            columns: class_project_status_columns['columns']
-          });
-        }
-      }
     }
     var chart = c3.generate({
       bindto: '#projectTypes',
-      data: data,
+      data: project_type_chart_data,
       donut: {
         title: "Project Types"
       },
@@ -95,12 +39,17 @@
     return chart;
   }
 
-  function drawProjectStatuses() {
+  function drawProjectUsers() {
     var chart = c3.generate({
-      bindto: '#projectStatuses',
-      data: project_status_chart_data,
+      bindto: '#projectUsers',
+      data: project_user_chart_data,
       donut: {
-        title: "Project Statuses"
+        title: "Project Users"
+      },
+      legend: {
+        item: {
+          onclick: function(id) { }
+        }
       }
     })
 

--- a/coldfront/components/site/templates/portal/user_summary.html
+++ b/coldfront/components/site/templates/portal/user_summary.html
@@ -5,7 +5,7 @@
   </div>
   <div class="col">
     <div id="userYearTimeline" style="min-height: 270px; max-width: 519px;"></div>
-    <div id="userMonthTimeline" style="min-height: 270px; max-width: 519px;"></div>
+    <!-- <div id="userMonthTimeline" style="min-height: 270px; max-width: 519px;"></div> -->
   </div>
 </div>
 

--- a/coldfront/components/site/templates/project/project_detail.html
+++ b/coldfront/components/site/templates/project/project_detail.html
@@ -395,6 +395,11 @@ Project Detail
                 <a href="{% url 'allocation-detail' allocation.pk %}">
                   <i title="Details" class="far fa-folder-open" aria-hidden="true"></i><span class="sr-only">Details</span>
                 </a>
+                {% if is_allowed_to_update_project and allocation.status.name in 'Active, Billing Information Submitted' %}
+                  <a href="{% url 'allocation-remove' pk=allocation.pk %}?from_project=true">
+                    <i title="Remove access" class="far fa-times-circle" aria-hidden="true"></i><span class="sr-only">Remove access</span>
+                  </a>
+                {% endif %}
                 {% if allocation.project.requires_review %}
                   {% if allocation.is_locked and allocation.status.name == 'Active' and allocation.expires_in <= ALLOCATION_DAYS_TO_REVIEW_BEFORE_EXPIRING and allocation.expires_in >= 0 %}
                     <span class="badge badge-warning"><i class="far fa-clock" aria-hidden="true"></i>

--- a/coldfront/components/site/templates/project/project_review.html
+++ b/coldfront/components/site/templates/project/project_review.html
@@ -20,8 +20,8 @@ Review Project
 
   <ol>
     <li><a href="{% url 'project-update' project.pk %}"><i class="fas fa-external-link-alt" aria-hidden="true"></i> Verify</a> your project description is accurate</li>
-    <!-- <li><a href="{% url 'publication-search' project.pk %}"><i class="fas fa-external-link-alt" aria-hidden="true"></i> Add</a> Publications</li>
-    <li><a href="{% url 'grant-create' project.pk %}"><i class="fas fa-external-link-alt" aria-hidden="true"></i> Add</a> Grants</li> -->
+    <li><a href="{% url 'publication-search' project.pk %}"><i class="fas fa-external-link-alt" aria-hidden="true"></i> Add</a> Publications</li>
+    <!-- <li><a href="{% url 'grant-create' project.pk %}"><i class="fas fa-external-link-alt" aria-hidden="true"></i> Add</a> Grants</li> -->
     <li><a href="{% url 'project-remove-users' project.pk %}"><i class="fas fa-external-link-alt" aria-hidden="true"></i> Verify</a> the user accounts in your group and remove any that should no longer have access to {% settings_value 'CENTER_NAME' %} resources</li>
   </ol>
 
@@ -30,11 +30,11 @@ Review Project
       <!-- <tr>
         <th scope="row" class="text-nowrap">Grants Last Updated:</th>
         <td>{{project.latest_grant.modified|date:"M. d, Y"|default:"No grants"}}</td>
-      </tr>
+      </tr> -->
       <tr>
         <th scope="row" class="text-nowrap">Publications Last Updated:</th>
         <td>{{project.latest_publication.created|date:"M. d, Y"|default:"No publications"}}</td>
-      </tr> -->
+      </tr>
       <tr>
         <th scope="row" class="text-nowrap">Users in project:</th>
         <td>{{project_users}}</td>
@@ -42,10 +42,6 @@ Review Project
     </table>
   </div>
 </div>
-
-{% if academics_analytics_enabled %}
-  {% include "academic_analytics/academic_analytics_div.html" with project_pk=project.pk project_type=project.type.name %}
-{% endif %}
 
 <form method="post">
   {% csrf_token %}

--- a/coldfront/components/site/templates/project/project_review_list.html
+++ b/coldfront/components/site/templates/project/project_review_list.html
@@ -43,7 +43,7 @@ Project Review List
             {% else %}
               <td></td>
             {% endif %}
-            <td class="no-textwrap">
+            <td class="no-textwrap" style="white-space: nowrap;">
               <a href="{% url 'project-activate-request' project_request.pk %}" class="btn btn-success mr-1">Activate</a>
               <a href="{% url 'project-deny-request' project_request.pk %}" class="btn btn-danger mr-1">Deny</a>
               {% if EMAIL_ENABLED %}

--- a/coldfront/core/allocation/admin.py
+++ b/coldfront/core/allocation/admin.py
@@ -20,7 +20,9 @@ from coldfront.core.allocation.models import (Allocation, AllocationAccount,
                                               AllocationUserRequest,
                                               AllocationInvoice,
                                               AllocationAdminAction,
-                                              AttributeType,)
+                                              AttributeType,
+                                              AllocationRemovalRequest,
+                                              AllocationRemovalStatusChoice,)
 
 
 @admin.register(AllocationStatusChoice)
@@ -542,3 +544,18 @@ class AllocationAdminActionAdmin(admin.ModelAdmin):
 
     def allocation_pk(self, obj):
         return obj.allocation.pk
+
+
+@admin.register(AllocationRemovalRequest)
+class AllocationRemovalRequestAdmin(admin.ModelAdmin):
+    list_display = ('pk', 'project_pi', 'requestor', 'allocation_prior_status', 'resource', 'status')
+    readonly_fields = ('project_pi', 'requestor', 'allocation_prior_status')
+
+    def resource(self, obj):
+        allocation_obj = obj.allocation
+        return allocation_obj.get_parent_resource.resource_type.name
+
+
+@admin.register(AllocationRemovalStatusChoice)
+class AllocationRemovalStatusChoiceAdmin(admin.ModelAdmin):
+    list_display = ('pk', 'name')

--- a/coldfront/core/allocation/models.py
+++ b/coldfront/core/allocation/models.py
@@ -751,3 +751,21 @@ class AllocationAdminAction(TimeStampedModel):
     user = models.ForeignKey(User, on_delete=models.CASCADE)
     allocation = models.ForeignKey(Allocation, on_delete=models.CASCADE)
     action = models.CharField(max_length=128)
+
+
+class AllocationRemovalStatusChoice(TimeStampedModel):
+    name = models.CharField(max_length=64)
+
+    def __str__(self):
+        return self.name
+
+    class Meta:
+        ordering = ['name', ]
+
+
+class AllocationRemovalRequest(TimeStampedModel):
+    project_pi = models.ForeignKey(User, on_delete=models.CASCADE, related_name='%(class)s_project_pi')
+    requestor = models.ForeignKey(User, on_delete=models.CASCADE, related_name='%(class)s_requestor')
+    allocation = models.ForeignKey(Allocation, on_delete=models.CASCADE)
+    allocation_prior_status = models.ForeignKey(AllocationStatusChoice, on_delete=models.CASCADE)
+    status = models.ForeignKey(AllocationRemovalStatusChoice, on_delete=models.CASCADE)

--- a/coldfront/core/allocation/urls.py
+++ b/coldfront/core/allocation/urls.py
@@ -78,8 +78,8 @@ urlpatterns = [
          name='allocation-remove'),
     path('removal-list/', allocation_views.AllocationRemovalListView.as_view(),
          name='allocation-removal-request-list'),
-    path('<int:pk>/allocation-approve-removal/', allocation_views.AllocationApproveRemovalView.as_view(),
+    path('<int:pk>/allocation-approve-removal/', allocation_views.AllocationApproveRemovalRequestView.as_view(),
          name='allocation-approve-removal-request'),
-    path('<int:pk>/allocation-deny-removal/', allocation_views.AllocationDenyRemovalRequest.as_view(),
+    path('<int:pk>/allocation-deny-removal/', allocation_views.AllocationDenyRemovalRequestView.as_view(),
          name='allocation-deny-removal-request')
 ]

--- a/coldfront/core/allocation/views.py
+++ b/coldfront/core/allocation/views.py
@@ -1477,9 +1477,16 @@ class AllocationCreateView(LoginRequiredMixin, UserPassesTestMixin, FormView):
                                       allocation_obj.project.pi.last_name, allocation_obj.project.pi.username)
         domain_url = get_domain_url(self.request)
         url = '{}{}'.format(domain_url, reverse('allocation-request-list'))
+        project_detail_url = '{}{}'.format(
+            domain_url, reverse('project-detail', kwargs={'pk': allocation_obj.project.pk})
+        )
         resource_name = allocation_obj.get_parent_resource
         if SLACK_MESSAGING_ENABLED:
-            text = f'A new allocation in project "{project_obj.title}" with id {project_obj.pk} has been requested for {pi_name} - {resource_name}. Please review the allocation: {url}'
+            text = (
+                f'A new allocation in project "{project_obj.title}" with id {project_obj.pk} has '
+                f'been requested for {pi_name} - {resource_name}. Please review the allocation: '
+                f'{url}. Project detail url: {project_detail_url}'
+            )
             send_message(text)
         if EMAIL_ENABLED:
             template_context = {
@@ -1487,7 +1494,8 @@ class AllocationCreateView(LoginRequiredMixin, UserPassesTestMixin, FormView):
                 'project_id': project_obj.pk,
                 'pi': pi_name,
                 'resource': resource_name,
-                'url': url
+                'url': url,
+                'project_detail_url': project_detail_url
             }
 
             email_recipient = get_email_recipient_from_groups(

--- a/coldfront/core/allocation/views.py
+++ b/coldfront/core/allocation/views.py
@@ -1258,7 +1258,6 @@ class AllocationCreateView(LoginRequiredMixin, UserPassesTestMixin, FormView):
                 end_date = self.calculate_end_date(int(month), int(day))
         elif end_date > project_obj.end_date:
             end_date = project_obj.end_date
-        
 
         if resource_obj.name == 'Slate-Project':
             storage_space_unit = 'TB'
@@ -1333,6 +1332,8 @@ class AllocationCreateView(LoginRequiredMixin, UserPassesTestMixin, FormView):
             allocation_status_obj = AllocationStatusChoice.objects.get(
                 name='New')
 
+        official_end_date = form_data['end_date']
+
         form_data.pop('cost')
         form_data.pop('users')
         form_data.pop('resource')
@@ -1347,6 +1348,7 @@ class AllocationCreateView(LoginRequiredMixin, UserPassesTestMixin, FormView):
         form_data['storage_space_unit'] = storage_space_unit
         allocation_obj = Allocation.objects.create(**form_data)
         form_data['use_type'] = use_type
+        form_data['end_date'] = official_end_date
 
         if ALLOCATION_ENABLE_CHANGE_REQUESTS_BY_DEFAULT:
             allocation_obj.is_changeable = True

--- a/coldfront/core/portal/utils.py
+++ b/coldfront/core/portal/utils.py
@@ -145,6 +145,36 @@ def generate_project_type_chart_data():
     return project_type_chart_data
 
 
+def generate_project_user_chart_data():
+    project_statuses = ['Active', 'Waiting For Admin Approval', 'Review Pending', 'Contacted By Admin', ]
+    num_active_research_users = len(ProjectUser.objects.filter(
+        status__name='Active',
+        project__type__name='Research',
+        project__status__name__in=project_statuses
+    ))
+    num_active_class_users = len(ProjectUser.objects.filter(
+        status__name='Active',
+        project__type__name='Class',
+        project__status__name__in=project_statuses
+    ))
+
+    active_research_users_label = f'Research: {num_active_research_users}'
+    active_class_users_label = f'Class: {num_active_class_users}'
+    project_user_chart_data = {
+        'columns': [
+            [active_research_users_label, num_active_research_users],
+            [active_class_users_label, num_active_class_users],
+        ],
+        'type': 'donut',
+        'colors': {
+            active_class_users_label: '#e27602',
+            active_research_users_label: '#673ab7',
+        }
+    }
+
+    return project_user_chart_data
+
+
 def generate_project_status_chart_data():
     num_active_projects = Project.objects.filter(status__name='Active').count()
     num_requested_projects = Project.objects.filter(status__name__in=['Waiting For Admin Approval', 'Contacted By Admin', ]).count()

--- a/coldfront/core/portal/views.py
+++ b/coldfront/core/portal/views.py
@@ -14,9 +14,7 @@ from coldfront.core.portal.utils import (generate_allocations_chart_data,
                                          generate_resources_chart_data,
                                          generate_total_grants_by_agency_chart_data,
                                          generate_project_type_chart_data,
-                                         generate_project_status_chart_data,
-                                         generate_research_project_status_columns,
-                                         generate_class_project_status_columns,
+                                         generate_project_user_chart_data,
                                          generate_user_counts,
                                          generate_user_timeline)
 from coldfront.core.project.models import Project
@@ -219,20 +217,11 @@ def allocation_summary(request):
 
 @cache_page(60 * 15)
 def project_summary(request):
-    project_status_chart_data = generate_project_status_chart_data()
-    research_project_status_columns = generate_research_project_status_columns()
-    class_project_status_columns = generate_class_project_status_columns()
-    project_status_chart_data['colors'].update(research_project_status_columns['colors'])
-    project_status_chart_data['colors'].update(class_project_status_columns['colors'])
-
     context = {}
-    context['project_status_chart_data'] = project_status_chart_data
+    context['project_user_chart_data'] = generate_project_user_chart_data()
     context['project_type_chart_data'] = generate_project_type_chart_data()
-    context['research_project_status_columns'] = research_project_status_columns
-    context['class_project_status_columns'] = class_project_status_columns
 
     return render(request, 'portal/project_summary.html', context)
-
 
 
 @cache_page(60 * 15)

--- a/coldfront/core/project/views.py
+++ b/coldfront/core/project/views.py
@@ -1961,11 +1961,6 @@ class ProjectReviewView(LoginRequiredMixin, UserPassesTestMixin, TemplateView):
             formset = formset(initial=allocation_data, prefix='allocationform')
             context['formset'] = formset
 
-        context['academics_analytics_enabled'] = False
-        if 'coldfront.plugins.academic_analytics' in settings.INSTALLED_APPS:
-            context['academics_analytics_enabled'] = True
-            context['username'] = request.user.username
-
         return render(request, self.template_name, context)
 
     def post(self, request, *args, **kwargs):

--- a/coldfront/core/project/views.py
+++ b/coldfront/core/project/views.py
@@ -1915,6 +1915,7 @@ class ProjectReviewView(LoginRequiredMixin, UserPassesTestMixin, TemplateView):
     def get_allocation_data(self, project_obj):
         allocations = project_obj.allocation_set.filter(
             status__name__in=['Active', 'Expired', ],
+            is_locked=False,
             resources__requires_payment=False
         )
         initial_data = []

--- a/coldfront/core/project/views.py
+++ b/coldfront/core/project/views.py
@@ -2629,7 +2629,7 @@ class ProjectRequestEmailView(LoginRequiredMixin, UserPassesTestMixin, FormView)
             send_email(
                 'Request for more information',
                 form_data.get('email_body'),
-                EMAIL_SENDER,
+                EMAIL_TICKET_SYSTEM_ADDRESS,
                 receiver_list,
                 cc
             )

--- a/coldfront/core/publication/forms.py
+++ b/coldfront/core/publication/forms.py
@@ -18,6 +18,9 @@ class PublicationSearchForm(forms.Form):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.fields['search_id'].help_text = '<br/>Enter ID such as DOI or Bibliographic Code to search.'
+        self.fields['search_id'].widget.attrs.update({
+             'placeholder': '12.3456/1234567.8912345 OR YYYYJJJJJVVVVMPPPPA'
+        })
 
 
 class PublicationResultForm(forms.Form):

--- a/coldfront/plugins/academic_analytics/views.py
+++ b/coldfront/plugins/academic_analytics/views.py
@@ -38,7 +38,8 @@ class AcademicAnalyticsPublications(LoginRequiredMixin, UserPassesTestMixin, Tem
         context = {}
         context['project_pk'] = request.GET.get('project_pk')
         context['publication_formset'] = []
-        publication_data = get_publications(request.user.username)
+        usernames = project_obj.projectuser_set.filter(status__name='Active').values_list('user__username', flat=True)
+        publication_data = get_publications(usernames)
         publication_data = remove_existing_publications(project_obj, publication_data)
         if publication_data:
             publication_formset = formset_factory(PublicationForm, max_num=len(publication_data))
@@ -53,7 +54,8 @@ class AcademicAnalyticsPublications(LoginRequiredMixin, UserPassesTestMixin, Tem
         context = {}
         context['project_pk'] = request.POST.get('project_pk')
         context['publication_formset'] = []
-        publication_data = get_publications(request.user.username)
+        usernames = project_obj.projectuser_set.filter(status__name='Active').values_list('user__username', flat=True)
+        publication_data = get_publications(usernames)
         publication_data = remove_existing_publications(project_obj, publication_data)
         if publication_data:
             publication_formset = formset_factory(PublicationForm, max_num=len(publication_data))

--- a/coldfront/plugins/advanced_search/forms.py
+++ b/coldfront/plugins/advanced_search/forms.py
@@ -158,10 +158,6 @@ class SearchForm(forms.Form):
 
     resources__name = forms.ModelMultipleChoiceField(
         label='Resource Name',
-        help_text= (
-            f'The selection of allocation attributes is only updated of after the search form is '
-            f'submitted.'
-        ),
         queryset=Resource.objects.filter(is_allocatable=True).order_by('name'),
         required=False
     )
@@ -186,24 +182,37 @@ class SearchForm(forms.Form):
             Accordion(
                 AccordionGroup('Projects',
                     'only_search_projects',
-                    'project__title',
-                    'project__description',
-                    'project__pi__username',
-                    'project__requestor__username',
-                    'project__user_username',
-                    'project__status__name',
-                    'project__type__name',
-                    'project__class_number',
-                    'display__project__id',
-                    'display__project__title',
-                    'display__project__description',
-                    'display__project__pi__username',
-                    'display__project__requestor__username',
-                    'display__project__status__name',
-                    'display__project__type__name',
-                    'display__project__class_number',
-                    'display__project__users',
-                    'display__project__total_users',
+                    Accordion(
+                        AccordionGroup(
+                            'Filters',
+                            'project__title',
+                            'project__description',
+                            'project__pi__username',
+                            'project__requestor__username',
+                            'project__user_username',
+                            'project__status__name',
+                            'project__type__name',
+                            'project__class_number',
+                            active=False,
+                        ),
+                    ),
+                    Accordion(
+                        AccordionGroup(
+                            'Displays',
+                            'display__project__id',
+                            'display__project__title',
+                            'display__project__description',
+                            'display__project__pi__username',
+                            'display__project__requestor__username',
+                            'display__project__status__name',
+                            'display__project__type__name',
+                            'display__project__class_number',
+                            'display__project__users',
+                            'display__project__total_users',
+                            active=False,
+                        ),
+                    ),
+                    active=False,
                 ),
             ),
             Accordion(
@@ -213,7 +222,8 @@ class SearchForm(forms.Form):
                     'display__allocation__id',
                     'display__allocation__status__name',
                     'display__allocation__users',
-                    'display__allocation__total_users'
+                    'display__allocation__total_users',
+                    active=False,
                 )
             ),
             Accordion(
@@ -221,7 +231,8 @@ class SearchForm(forms.Form):
                     'resources__name',
                     'resources__resource_type__name',
                     'display__resources__name',
-                    'display__resources__resource_type__name'
+                    'display__resources__resource_type__name',
+                    active=False,
                 )
             ),
             Accordion(
@@ -229,7 +240,8 @@ class SearchForm(forms.Form):
                     Formset('allocationattribute_form', 'allocationattribute_helper', label='allocationattribute_formset'),
                     HTML(
                         '<button id="id_formset_add_allocation_attribute_button" type="button" class="btn btn-primary">Add Allocation Attribute</button>'
-                    )
+                    ),
+                    active=False,
                 )
             ),
             FormActions(

--- a/coldfront/plugins/advanced_search/forms.py
+++ b/coldfront/plugins/advanced_search/forms.py
@@ -134,7 +134,8 @@ class SearchForm(forms.Form):
     display__project__class_number = forms.BooleanField(required=False)
 
     display__project__users = forms.BooleanField(
-        required=False, help_text='Active users. Ignored if "only search projects" is not selected'
+        required=False,
+        help_text='Active users. Enable by selecting "only search projects". Enables the user profiles section.'
     )
 
     display__project__total_users = forms.BooleanField(required=False, help_text='Active users')
@@ -152,7 +153,9 @@ class SearchForm(forms.Form):
     )
     display__allocation__status__name = forms.BooleanField(required=False)
 
-    display__allocation__users = forms.BooleanField(required=False, help_text='Active users')
+    display__allocation__users = forms.BooleanField(
+        required=False, help_text='Active users. Enables the user profiles section.'
+    )
 
     display__allocation__total_users = forms.BooleanField(required=False, help_text='Active users')
 
@@ -172,6 +175,12 @@ class SearchForm(forms.Form):
 
     allocationattribute_form = AllocationAttributeSearchForm()
     allocationattribute_helper = AllocationAttributeFormSetHelper()
+
+    user_profile__department = forms.CharField(label="Department Contains", max_length=100, required=False)
+    display__user_profile__department = forms.BooleanField(required=False)
+
+    user_profile__title = forms.CharField(label="Title Contains", max_length=30, required=False)
+    display__user_profile__title = forms.BooleanField(required=False)
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -243,6 +252,15 @@ class SearchForm(forms.Form):
                     ),
                     active=False,
                 )
+            ),
+            Accordion(
+                AccordionGroup('User Profiles',
+                    'user_profile__department',
+                    'user_profile__title',
+                    'display__user_profile__department',
+                    'display__user_profile__title',
+                    active=False,
+                ),
             ),
             FormActions(
                 Submit('submit', 'Search'),

--- a/coldfront/plugins/advanced_search/templates/advanced_search/advanced_search.html
+++ b/coldfront/plugins/advanced_search/templates/advanced_search/advanced_search.html
@@ -78,6 +78,7 @@ Project and Allocation Export List
   var rows = {{ rows | safe }}
   var form_count = {{ allocationattribute_form.total_form_count | safe}}
   var allocation_attribute_type_ids = {{ allocation_attribute_type_ids | safe}}
+  var linked_allocation_attribute_types = {{ linked_allocation_attribute_types | safe }}
 
   function toggleUsageFields(value, base_div_id) {
     if (allocation_attribute_type_ids.includes(value)) {
@@ -103,20 +104,72 @@ Project and Allocation Export List
     $(base_div_id + 'allocationattribute__usage_format').val('whole');
   }
 
+  function disableCollapsibleSection(collapsible, hyperlink) {
+    collapsible.removeClass().addClass('collapse');
+    hyperlink.toggleClass('ui-state-disabled');
+    hyperlink.addClass('collapsed');
+    hyperlink.prop('ariaExpanded', false);
+  }
+
   $(document).ready(function () {
+    if ($("#id_full_search-only_search_projects").is(":checked")) {
+      disableCollapsibleSection($("#allocations"), $('h5 > a[href="#allocations"]'));
+      disableCollapsibleSection($("#resources"), $('h5 > a[href="#resources"]'));
+      disableCollapsibleSection($("#allocation-attributes"), $('h5 > a[href="#allocation-attributes"]'));
+    } 
+
+    $("#id_full_search-only_search_projects").on('click', function () {
+      var is_checked = $("#id_full_search-only_search_projects").is(":checked");
+
+      disableCollapsibleSection($("#allocations"), $('h5 > a[href="#allocations"]'));
+      disableCollapsibleSection($("#resources"), $('h5 > a[href="#resources"]'));
+      disableCollapsibleSection($("#allocation-attributes"), $('h5 > a[href="#allocation-attributes"]'));
+    })
+
+    $("#id_full_search-resources__name").on('click', function(evt) {
+      options = [];
+      selected_resources = $("#id_full_search-resources__name").val();
+      for (let i = 0; i < selected_resources.length; i++) {
+        options.push(linked_allocation_attribute_types[selected_resources[i]]);
+      }
+
+      var options_set = new Set();
+      options.flat().forEach(element => {
+        options_set.add(element);
+      });
+
+      matches = $("[id*=allocationattribute__name]");
+      for (let i = 0; i < matches.length; i++) {
+        id = matches[i].id;
+        
+        if (!id.includes('div') && !id.includes('hint')) {
+          value = $("#" + id + " option:selected").val();
+          matches[i].innerHTML = '<option value="">---------</option>' + Array.from(options_set).toString().replace(',', '');
+          $("#" + id).val(value).change();
+          value = $("#" + id + " option:selected").val();
+          if (value === undefined) {
+            $("#" + id).val("").change();
+
+            base_id = "#" + id.slice(0, id.length - 25);
+            resetAllocationAttributeFieldsToDefaults(base_id);
+          }
+        }
+      } 
+    })
+
     $("[id*='allocationattribute__name']").each(function (data) {
-      id = $(this)[0].id
+      id = $(this)[0].id;
       if (id.includes('div')) {
         return;
       }
 
       $(this).on('change', function (evt) {
         id = evt.target.id
-        base_div_id = '#div_' + id.slice(0, id.indexOf('-', id.indexOf('-') + 1) + 1)
+        base_div_id = '#div_' + id.slice(0, id.indexOf('-', id.indexOf('-') + 1) + 1);
         toggleUsageFields(parseInt(evt.target.value), base_div_id);
       })
 
-      base_div_id = '#div_' + id.slice(0, id.indexOf('-', id.indexOf('-') + 1) + 1)
+      base_div_id = '#div_' + id.slice(0, id.indexOf('-', id.indexOf('-') + 1) + 1);
       toggleUsageFields(parseInt(id = $(this)[0].value), base_div_id);
     })
   })
@@ -127,11 +180,11 @@ Project and Allocation Export List
     row.innerHTML = row.innerHTML.replaceAll('-0-', '-' + form_count + '-');
     $("#id_allocationattribute_formset").append(row);
 
-    var allocationattribute__name_field = $('#id_allocationattribute-' + form_count + '-allocationattribute__name')
+    var allocationattribute__name_field = $('#id_allocationattribute-' + form_count + '-allocationattribute__name');
 
     allocationattribute__name_field.on('change', function (evt) {
-      id = evt.target.id
-      base_div_id = '#div_' + id.slice(0, id.indexOf('-', id.indexOf('-') + 1) + 1)
+      id = evt.target.id;
+      base_div_id = '#div_' + id.slice(0, id.indexOf('-', id.indexOf('-') + 1) + 1);
       toggleUsageFields(parseInt(evt.target.value), base_div_id);
     })
 

--- a/coldfront/plugins/advanced_search/templates/advanced_search/advanced_search.html
+++ b/coldfront/plugins/advanced_search/templates/advanced_search/advanced_search.html
@@ -104,7 +104,7 @@ Project and Allocation Export List
     $(base_div_id + 'allocationattribute__usage_format').val('whole');
   }
 
-  function disableCollapsibleSection(collapsible, hyperlink) {
+  function toggleCollapsibleSection(collapsible, hyperlink) {
     collapsible.removeClass().addClass('collapse');
     hyperlink.toggleClass('ui-state-disabled');
     hyperlink.addClass('collapsed');
@@ -112,18 +112,60 @@ Project and Allocation Export List
   }
 
   $(document).ready(function () {
+    toggleCollapsibleSection($("#user-profiles"), $('h5 > a[href="#user-profiles"]'));
+
     if ($("#id_full_search-only_search_projects").is(":checked")) {
-      disableCollapsibleSection($("#allocations"), $('h5 > a[href="#allocations"]'));
-      disableCollapsibleSection($("#resources"), $('h5 > a[href="#resources"]'));
-      disableCollapsibleSection($("#allocation-attributes"), $('h5 > a[href="#allocation-attributes"]'));
-    } 
+      toggleCollapsibleSection($("#allocations"), $('h5 > a[href="#allocations"]'));
+      toggleCollapsibleSection($("#resources"), $('h5 > a[href="#resources"]'));
+      toggleCollapsibleSection($("#allocation-attributes"), $('h5 > a[href="#allocation-attributes"]'));
+      $('#id_full_search-display__project__users').prop('disabled', false);
+      if ($("#id_full_search-display__project__users").is(":checked")) {
+        toggleCollapsibleSection($("#user-profiles"), $('h5 > a[href="#user-profiles"]'));
+      }
+    } else {
+      $('#id_full_search-display__project__users').prop('disabled', true);
+      if ($("#id_full_search-display__allocation__users").is(":checked")) {
+        toggleCollapsibleSection($("#user-profiles"), $('h5 > a[href="#user-profiles"]'));
+      }
+    }
 
     $("#id_full_search-only_search_projects").on('click', function () {
       var is_checked = $("#id_full_search-only_search_projects").is(":checked");
 
-      disableCollapsibleSection($("#allocations"), $('h5 > a[href="#allocations"]'));
-      disableCollapsibleSection($("#resources"), $('h5 > a[href="#resources"]'));
-      disableCollapsibleSection($("#allocation-attributes"), $('h5 > a[href="#allocation-attributes"]'));
+      toggleCollapsibleSection($("#allocations"), $('h5 > a[href="#allocations"]'));
+      toggleCollapsibleSection($("#resources"), $('h5 > a[href="#resources"]'));
+      toggleCollapsibleSection($("#allocation-attributes"), $('h5 > a[href="#allocation-attributes"]'));
+      display_project_users = $('#id_full_search-display__project__users');
+      if (is_checked) {
+        display_project_users.prop('disabled', false);
+        if ($("#id_full_search-display__project__users").is(":checked")) {
+          if ($('h5 > a[href="#user-profiles"]').hasClass('ui-state-disabled')) {
+            toggleCollapsibleSection($("#user-profiles"), $('h5 > a[href="#user-profiles"]'));
+          }
+        } else {
+          if (!$('h5 > a[href="#user-profiles"]').hasClass('ui-state-disabled')) {
+            toggleCollapsibleSection($("#user-profiles"), $('h5 > a[href="#user-profiles"]'));
+          }
+        }
+      } else {
+        display_project_users.prop('disabled', true);
+        if ($("#id_full_search-display__allocation__users").is(":checked")) {
+          if ($('h5 > a[href="#user-profiles"]').hasClass('ui-state-disabled')) {
+            toggleCollapsibleSection($("#user-profiles"), $('h5 > a[href="#user-profiles"]'));
+          }
+        } else {
+          if (!$('h5 > a[href="#user-profiles"]').hasClass('ui-state-disabled')) {
+            toggleCollapsibleSection($("#user-profiles"), $('h5 > a[href="#user-profiles"]'));
+          }
+        }
+      }
+    })
+
+    $("#id_full_search-display__project__users").on('click', function () {
+      toggleCollapsibleSection($("#user-profiles"), $('h5 > a[href="#user-profiles"]'));
+    })
+    $("#id_full_search-display__allocation__users").on('click', function () {
+      toggleCollapsibleSection($("#user-profiles"), $('h5 > a[href="#user-profiles"]'));
     })
 
     $("#id_full_search-resources__name").on('click', function(evt) {

--- a/coldfront/plugins/advanced_search/views.py
+++ b/coldfront/plugins/advanced_search/views.py
@@ -64,6 +64,18 @@ class AdvancedSearchView(LoginRequiredMixin, UserPassesTestMixin, TemplateView):
         helper = AllocationAttributeFormSetHelper()
         context['allocationattribute_helper'] = helper
 
+        linked_allocation_attribute_types = {}
+        for allocation_attribute_type in AllocationAttributeType.objects.all():
+            resources = allocation_attribute_type.linked_resources.all()
+            if resources.exists():
+                for resource in resources:
+                    if not linked_allocation_attribute_types.get(resource.id):
+                        linked_allocation_attribute_types[resource.id] = []
+
+                    linked_allocation_attribute_types[resource.id].append(
+                        f'<option value="{allocation_attribute_type.id}">{allocation_attribute_type}</option>'
+                    )
+
         if search_form.is_valid():
             data = search_form.cleaned_data
             rows, columns = build_table(data, allocationattribute_data, self.request.GET)
@@ -76,6 +88,7 @@ class AdvancedSearchView(LoginRequiredMixin, UserPassesTestMixin, TemplateView):
         context['entries'] = num_rows
         context['rows'] = rows
         context['allocation_attribute_type_ids'] = allocation_attribute_types_with_usage
+        context['linked_allocation_attribute_types'] = linked_allocation_attribute_types
         return context
 
 


### PR DESCRIPTION
Changes:
- Updated the center summary by removing the title, replacing the project status graph with a project users graph, and removing the monthly view of the total unique users on the site.
- Locked allocations can no longer be renewed during a project renewal.
- Fixed project review buttons wrapping when they shouldn't be.
- Made a couple of QOL changes for the advanced search plugins. Sections are now collapsed by default, certain selections now disable sections that will be ignored, the projects section is now divided between display and filter, and allocation attributes update automatically when a resource is selected.
- Added the user profiles section to the advanced search page.
- Added the link to the publications page back into the project renewal page. The academic analytics publication list now only exists on that page.
- The academic analytics plugin now searches everyone who is active in the project.
- Fixed the end date allocation attribute not being saved correctly when an end date is given in a form.
- Allocation removal requests have been improved. They are now saved in a table to keep a record of them, more information can be grabbed about the request, and the requests can be made before and after an allocation is approved.
- Fix the incorrect email sending the email requesting for more information about a project.
- Added a project detail URL to the new allocation request notifications.