### PR TITLE
Coldfront internal update

### DIFF
--- a/coldfront/components/site/templates/allocation/allocation_detail.html
+++ b/coldfront/components/site/templates/allocation/allocation_detail.html
@@ -116,20 +116,21 @@ Allocation Detail
                       </span>
                     </a>
                   {% elif is_allowed_to_update_project and ALLOCATION_ENABLE_ALLOCATION_RENEWAL and allocation.status.name == 'Expired' and ALLOCATION_DAYS_TO_REVIEW_AFTER_EXPIRING < 0  %}
-                    <a href="{% url 'allocation-renew' allocation.pk %}">
-                      {% if allocation.can_be_renewed %}
+                    {% if allocation.can_be_renewed %}
+                      <a href="{% url 'allocation-renew' allocation.pk %}">
                         <span class="badge badge-warning"><i class="fas fa-redo-alt" aria-hidden="true"></i>
                           Click to renew 
                         </span>
-                      {% endif %}
-                    </a>
+                      </a>
+                    {% endif %}
                   {% elif is_allowed_to_update_project and ALLOCATION_ENABLE_ALLOCATION_RENEWAL and allocation.status.name == 'Expired' and allocation.expires_in >= ALLOCATION_DAYS_TO_REVIEW_AFTER_EXPIRING|change_sign %}
-                    <a href="{% url 'allocation-renew' allocation.pk %}">
-                      <span class="badge badge-warning"><i class="fas fa-redo-alt" aria-hidden="true"></i>
-                        {{ allocation.expires_in|add:ALLOCATION_DAYS_TO_REVIEW_AFTER_EXPIRING }} days left to renew
-                        {% if allocation.can_be_renewed %} Click to renew {% endif %}
-                      </span>
-                    </a>
+                    {% if allocation.can_be_renewed %}
+                      <a href="{% url 'allocation-renew' allocation.pk %}">
+                        <span class="badge badge-warning"><i class="fas fa-redo-alt" aria-hidden="true"></i>
+                          {{ allocation.expires_in|add:ALLOCATION_DAYS_TO_REVIEW_AFTER_EXPIRING }} days left to renew - Click to renew
+                        </span>
+                      </a>
+                    {% endif %}
                   {% endif %}
                 {% endif %}
               </td>

--- a/coldfront/components/site/templates/project/project_detail.html
+++ b/coldfront/components/site/templates/project/project_detail.html
@@ -339,19 +339,20 @@ Project Detail
                       </span>
                     </a>
                   {% elif is_allowed_to_update_project and ALLOCATION_ENABLE_ALLOCATION_RENEWAL and allocation.status.name == 'Expired' and ALLOCATION_DAYS_TO_REVIEW_AFTER_EXPIRING < 0  %}
-                    <a href="{% url 'allocation-renew' allocation.pk %}">
-                      {% if allocation.can_be_renewed %}
+                    {% if allocation.can_be_renewed %}  
+                      <a href="{% url 'allocation-renew' allocation.pk %}">
                         <span class="badge badge-warning"><i class="fas fa-redo-alt" aria-hidden="true"></i>
                           Click to renew 
                         </span>
-                      {% endif %}
-                    </a>
+                      </a>
+                    {% endif %}
                   {% elif is_allowed_to_update_project and ALLOCATION_ENABLE_ALLOCATION_RENEWAL and allocation.status.name == 'Expired' and allocation.expires_in >= ALLOCATION_DAYS_TO_REVIEW_AFTER_EXPIRING|change_sign %}
                     <a href="{% url 'allocation-renew' allocation.pk %}">
-                      <span class="badge badge-warning"><i class="fas fa-redo-alt" aria-hidden="true"></i>
-                        {{ allocation.expires_in|add:ALLOCATION_DAYS_TO_REVIEW_AFTER_EXPIRING }} days left to renew
-                        {% if allocation.can_be_renewed %} - Click to renew {% endif %}
-                      </span>
+                      {% if allocation.can_be_renewed %}
+                        <span class="badge badge-warning"><i class="fas fa-redo-alt" aria-hidden="true"></i>
+                          {{ allocation.expires_in|add:ALLOCATION_DAYS_TO_REVIEW_AFTER_EXPIRING }} days left to renew - Click to renew
+                        </span>
+                      {% endif %}
                     </a>
                   {% endif %}
                 {% endif %}

--- a/coldfront/core/allocation/management/commands/modify_allocation_locks.py
+++ b/coldfront/core/allocation/management/commands/modify_allocation_locks.py
@@ -1,0 +1,28 @@
+from django.core.management.base import BaseCommand, CommandError
+
+from coldfront.core.allocation.models import Allocation
+
+class Command(BaseCommand):
+    help = 'Lock/unlock all allocations containing a specific resource'
+
+    def add_arguments(self, parser):
+        parser.add_argument("--resource", type=str)
+        parser.add_argument("--lock", type=int)
+
+    def handle(self, *args, **kwargs):
+        resource = kwargs.get("resource")
+        if not resource:
+            raise CommandError("Please provide a resource")
+        
+        lock = kwargs.get("lock")
+        if lock not in [0, 1]:
+            raise CommandError("Please specify 0 (unlock) or 1 (lock)")
+        lock = bool(lock)
+        
+        allocation_objs = Allocation.objects.filter(resources__name=resource)
+        for allocation_obj in allocation_objs:
+            allocation_obj.is_locked = lock
+            allocation_obj.save()
+
+            print (allocation_obj.is_locked)
+

--- a/coldfront/core/allocation/management/commands/modify_allocation_locks.py
+++ b/coldfront/core/allocation/management/commands/modify_allocation_locks.py
@@ -1,22 +1,24 @@
+import logging
+
 from django.core.management.base import BaseCommand, CommandError
 
 from coldfront.core.allocation.models import Allocation
+
+logger = logging.getLogger(__name__)
+
 
 class Command(BaseCommand):
     help = 'Lock/unlock all allocations containing a specific resource'
 
     def add_arguments(self, parser):
-        parser.add_argument("--resource", type=str)
-        parser.add_argument("--lock", type=int)
+        parser.add_argument('--resource', type=str, required=True)
+        parser.add_argument('--lock', type=int, required=True)
 
     def handle(self, *args, **kwargs):
-        resource = kwargs.get("resource")
-        if not resource:
-            raise CommandError("Please provide a resource")
-        
-        lock = kwargs.get("lock")
+        resource = kwargs.get('resource')
+        lock = kwargs.get('lock')
         if lock not in [0, 1]:
-            raise CommandError("Please specify 0 (unlock) or 1 (lock)")
+            raise CommandError('Please specify 0 (unlock) or 1 (lock)')
         lock = bool(lock)
         
         allocation_objs = Allocation.objects.filter(resources__name=resource)
@@ -24,5 +26,4 @@ class Command(BaseCommand):
             allocation_obj.is_locked = lock
             allocation_obj.save()
 
-            print (allocation_obj.is_locked)
-
+        logger.info(f'All {resource} allocations were {"locked" if lock else "unlocked"}')

--- a/coldfront/core/allocation/views.py
+++ b/coldfront/core/allocation/views.py
@@ -2873,7 +2873,7 @@ class AllocationRenewView(LoginRequiredMixin, UserPassesTestMixin, TemplateView)
                 allocation_obj.status.name))
             return HttpResponseRedirect(reverse('allocation-detail', kwargs={'pk': allocation_obj.pk}))
 
-        if allocation_obj.project.status.name in ['Review Pending', 'Denied', 'Expired', ]:
+        if allocation_obj.project.status.name in ['Review Pending', 'Denied', 'Expired', 'Archived', ]:
             messages.error(
                 request, 'You cannot renew an allocation with project status "{}".'.format(
                     allocation_obj.project.status.name

--- a/coldfront/core/project/management/commands/modify_max_managers.py
+++ b/coldfront/core/project/management/commands/modify_max_managers.py
@@ -1,0 +1,26 @@
+import logging
+
+from django.core.management.base import BaseCommand, CommandError
+
+from coldfront.core.project.models import Project
+
+logger = logging.getLogger(__name__)
+
+
+class Command(BaseCommand):
+    help = 'Changes the allowed number of managers in all projects'
+
+    def add_arguments(self, parser):
+        parser.add_argument("max_managers", type=int)
+
+    def handle(self, *args, **kwargs):
+        max_managers = kwargs.get("max_managers")
+        if max_managers < 1:
+            raise CommandError("Max managers must be > 0")
+        
+        project_objs = Project.objects.all()
+        for project_obj in project_objs:
+            project_obj.max_managers = max_managers
+            project_obj.save()
+
+        logger.info(f"All projects' max managers were set to {max_managers}")

--- a/coldfront/core/project/views.py
+++ b/coldfront/core/project/views.py
@@ -684,6 +684,7 @@ class ProjectArchiveProjectView(LoginRequiredMixin, UserPassesTestMixin, Templat
             name='Expired')
         end_date = datetime.datetime.now()
         project.status = project_status_archive
+        project.end_date = end_date
         project.save()
         for allocation in project.allocation_set.filter(status__name='Active'):
             allocation.status = allocation_status_expired

--- a/coldfront/plugins/advanced_search/forms.py
+++ b/coldfront/plugins/advanced_search/forms.py
@@ -117,6 +117,8 @@ class ProjectSearchForm(forms.Form):
         label='Username Contains', max_length=25, required=False, help_text='Active user'
     )
 
+    display__project__slurm_account_name = forms.BooleanField(required=False)
+
     project__status__name = forms.ModelMultipleChoiceField(
         label='Project Status',
         queryset=ProjectStatusChoice.objects.all().order_by('name'),
@@ -195,6 +197,7 @@ class ProjectSearchForm(forms.Form):
                     'display__project__description',
                     'display__project__pi__username',
                     'display__project__requestor__username',
+                    'display__project__slurm_account_name',
                     'display__project__status__name',
                     'display__project__type__name',
                     'display__project__class_number',

--- a/coldfront/plugins/slate_project/signals.py
+++ b/coldfront/plugins/slate_project/signals.py
@@ -23,7 +23,8 @@ from coldfront.plugins.slate_project.utils import (add_user_to_slate_project_gro
                                                    change_users_slate_project_groups,
                                                    add_slate_project_groups,
                                                    send_expiry_email,
-                                                   sync_slate_project_users)
+                                                   sync_slate_project_users,
+                                                   sync_slate_project_ldap_group)
 
 @receiver(allocation_activate, sender=AllocationDetailView)
 @receiver(allocation_activate, sender=AllocationActivateRequestView)
@@ -97,7 +98,7 @@ def remove(sender, **kwargs):
         return
 
 @receiver(visit_allocation_detail, sender=AllocationDetailView)
-def sync_users(sender, **kwargs):
+def sync_slate_project(sender, **kwargs):
     allocation_pk = kwargs.get('allocation_pk')
     allocation_obj = Allocation.objects.get(pk=allocation_pk)
     if not allocation_obj.get_parent_resource.name == 'Slate Project':
@@ -105,4 +106,5 @@ def sync_users(sender, **kwargs):
     if not allocation_obj.status.name in ['Active', 'Renewal Requested']:
         return
 
+    sync_slate_project_ldap_group(allocation_obj)
     sync_slate_project_users(allocation_obj)

--- a/coldfront/plugins/slate_project/tasks.py
+++ b/coldfront/plugins/slate_project/tasks.py
@@ -2,6 +2,7 @@ import logging
 
 from coldfront.core.allocation.models import Allocation
 from coldfront.plugins.slate_project.utils import (sync_slate_project_users,
+                                                   sync_slate_project_ldap_group,
                                                    send_inactive_users_report,
                                                    send_ineligible_pi_report,
                                                    import_slate_projects,
@@ -17,6 +18,7 @@ def sync_all_slate_project_allocations():
     ldap_conn = LDAPModify()
     logger.info('Running sync...')
     for slate_project_allocation in slate_project_allocations:
+        sync_slate_project_ldap_group(slate_project_allocation, ldap_conn)
         sync_slate_project_users(slate_project_allocation, ldap_conn)
     logger.info('Sync complete')
 

--- a/coldfront/plugins/slate_project/utils.py
+++ b/coldfront/plugins/slate_project/utils.py
@@ -38,6 +38,7 @@ if ENABLE_LDAP_ELIGIBILITY_SERVER:
     SLATE_PROJECT_ACCOUNT = import_from_settings('SLATE_PROJECT_ACCOUNT') 
 EMAIL_ENABLED = import_from_settings('EMAIL_ENABLED', False)
 CENTER_BASE_URL = import_from_settings('CENTER_BASE_URL')
+PROJECT_DEFAULT_MAX_MANAGERS = import_from_settings('PROJECT_DEFAULT_MAX_MANAGERS', 3)
 if EMAIL_ENABLED:
     SLATE_PROJECT_EMAIL = import_from_settings('SLATE_PROJECT_EMAIL')
     EMAIL_SIGNATURE = import_from_settings('EMAIL_SIGNATURE')
@@ -897,7 +898,7 @@ def import_slate_projects(limit=None, json_file_name=None, out_file_name=None):
                 title=slate_project.get('project_title'),
                 description=slate_project.get('abstract'),
                 pi=user_obj,
-                max_managers=3,
+                max_managers=PROJECT_DEFAULT_MAX_MANAGERS,
                 requestor=user_obj,
                 type=ProjectTypeChoice.objects.get(name='Research'),
                 status=ProjectStatusChoice.objects.get(name='Active'),

--- a/coldfront/plugins/slate_project/utils.py
+++ b/coldfront/plugins/slate_project/utils.py
@@ -333,8 +333,8 @@ def check_slate_project_account(user, notifications_enabled, ldap_search_conn=No
             logger.info(
                 f'LDAP: Added user {user.username} to the HPFS ADS eligibility group'
             )
-        if notifications_enabled:
-            send_missing_account_email(user.email)
+            if notifications_enabled:
+                send_missing_account_email(user.email)
     elif not SLATE_PROJECT_ACCOUNT in accounts:
         if notifications_enabled:
             send_missing_account_email(user.email)

--- a/coldfront/plugins/slate_project/utils.py
+++ b/coldfront/plugins/slate_project/utils.py
@@ -70,6 +70,9 @@ def sync_slate_project_directory_name(allocation_obj, ldap_group):
         return
     slate_project_directory.value = ldap_group_split[1]
     slate_project_directory.save()
+    logger.info(
+        f'Slate Project attribute {allocation_attribute_type} was updated during sync'
+    )
 
 
 def sync_slate_project_ldap_group(allocation_obj, ldap_conn=None):
@@ -119,7 +122,7 @@ def sync_slate_project_ldap_group(allocation_obj, ldap_conn=None):
         allocation_ldap_group.value = ldap_group
         allocation_ldap_group.save()
         logger.info(
-            f'LDAP: "Slate Project LDAP group name changed" from {old_ldap_group} to {ldap_group}'
+            f'Slate Project LDAP group name changed from {old_ldap_group} to {ldap_group} during sync'
         )
         sync_slate_project_directory_name(allocation_obj, ldap_group)
     

--- a/coldfront/plugins/slate_project/utils.py
+++ b/coldfront/plugins/slate_project/utils.py
@@ -564,7 +564,7 @@ def add_user_to_slate_project_group(allocation_user_obj):
         ldap_group_gid += 1
 
     ldap_conn = LDAPModify()
-    added, output = ldap_conn.add_user(ldap_group_gid, username)
+    added, output = ldap_conn.add_user(username, ldap_group_gid)
     if not added:
         logger.error(
             f'LDAP: Failed to add user {username} to the slate project group with '

--- a/coldfront/plugins/slate_project/utils.py
+++ b/coldfront/plugins/slate_project/utils.py
@@ -716,13 +716,14 @@ def get_slate_project_info(username):
         )
         if not attribute_obj.exists():
             continue
+        directory = attribute_obj[0]
         owner = allocation_user_obj.allocation.project.pi.username
         # For imported projects that have a project owner who can't be a PI.
         if owner == 'thcrowe' and allocation_user_obj.allocation.project.requestor:
             owner = allocation_user_obj.allocation.project.requestor.username
         slate_projects.append(
             {
-                'name': attribute_obj.value.split('/')[-1],
+                'name': directory.value.split('/')[-1],
                 'access': allocation_user_obj.role.name,
                 'owner': allocation_user_obj.allocation.project.pi.username
             }

--- a/coldfront/plugins/slate_project/utils.py
+++ b/coldfront/plugins/slate_project/utils.py
@@ -926,24 +926,22 @@ def import_slate_projects(limit=None, json_file_name=None, out_file_name=None):
                 abstract = f'Slate Project {line_split[0]}'
                 project_title = f'Slate Project {line_split[0]}'
                 allocated_quantity = None
-                start_date = None
             else:
                 abstract = extra_project_information.get('abstract')
                 project_title = extra_project_information.get('project_title')
                 allocated_quantity = extra_project_information.get('allocated_quantity')
-                start_date = extra_project_information.get('start_date')
 
             slate_project = {
                 "namespace_entry": line_split[0],
                 "ldap_group": line_split[1],
                 "owner_netid": line_split[2],
-                "gid_number": line_split[3],
-                "read_write_users": line_split[4].split(' '),
-                "read_only_users": line_split[5].split(' '),
+                "gid_number": line_split[4],
+                "read_write_users": line_split[5].split(' '),
+                "read_only_users": line_split[6].split(' '),
                 "abstract": abstract,
                 "project_title": project_title,
                 "allocated_quantity": allocated_quantity,
-                "start_date": start_date
+                "start_date": '-'.join([line_split[3][:4], line_split[3][4:6], line_split[3][6:8]])
             }
             slate_projects.append(slate_project)
 
@@ -1043,10 +1041,7 @@ def import_slate_projects(limit=None, json_file_name=None, out_file_name=None):
 
         allocation_start_date = todays_date
         if slate_project.get('start_date'):
-            allocation_start_date = slate_project.get('start_date').split('/')
-            allocation_start_date = '-'.join(
-                [allocation_start_date[2], allocation_start_date[0], allocation_start_date[1]]
-            )
+            allocation_start_date = slate_project.get('start_date')
 
         allocation_obj, created = Allocation.objects.get_or_create(
             project=project_obj,

--- a/coldfront/plugins/slate_project/utils.py
+++ b/coldfront/plugins/slate_project/utils.py
@@ -91,7 +91,7 @@ def sync_slate_project_ldap_group(allocation_obj, ldap_conn=None):
             f'"{allocation_attribute_type}"'
         )
         return
-    ldap_group_gid = ldap_group_gid[0].value
+    ldap_group_gid = int(ldap_group_gid[0].value)
 
     if ldap_conn is None:
         ldap_conn = LDAPModify()
@@ -146,7 +146,7 @@ def sync_slate_project_users(allocation_obj, ldap_conn=None):
             f'"{allocation_attribute_type}"'
         )
         return
-    ldap_group_gid = ldap_group_gid[0].value
+    ldap_group_gid = int(ldap_group_gid[0].value)
 
     if ldap_conn is None:
         ldap_conn = LDAPModify()
@@ -557,7 +557,7 @@ def add_user_to_slate_project_group(allocation_user_obj):
             f'is missing the allocation attribute "{allocation_attribute_type}"'
         )
         return
-    ldap_group_gid = ldap_group_gid[0].value
+    ldap_group_gid = int(ldap_group_gid[0].value)
 
     user_role = allocation_user_obj.role.name
     if user_role == 'read only':
@@ -599,7 +599,7 @@ def remove_slate_project_groups(allocation_obj):
             f'missing the allocation attribute "{allocation_attribute_type}"'
         )
         return
-    ldap_group_gid = ldap_group_gid[0].value
+    ldap_group_gid = int(ldap_group_gid[0].value)
 
     ldap_conn = LDAPModify()
     removed, output = ldap_conn.remove_group(ldap_group_gid)
@@ -648,7 +648,7 @@ def remove_user_from_slate_project_group(allocation_user_obj):
             f'{allocation_obj.pk} is missing the allocation attribute {allocation_attribute_type}'
         )
         return
-    ldap_group_gid = ldap_group_gid[0].value
+    ldap_group_gid = int(ldap_group_gid[0].value)
     
     user_role = allocation_user_obj.role.name
     if user_role == 'read only':
@@ -685,7 +685,7 @@ def change_users_slate_project_groups(allocation_user_obj):
             f'{allocation_obj.pk} is missing the allocation attribute {allocation_attribute_type}'
         )
         return
-    ldap_group_gid = ldap_group_gid[0].value
+    ldap_group_gid = int(ldap_group_gid[0].value)
     
     new_role = allocation_user_obj.role.name
     if new_role == 'read/write':

--- a/coldfront/plugins/slate_project/utils.py
+++ b/coldfront/plugins/slate_project/utils.py
@@ -71,7 +71,8 @@ def sync_slate_project_directory_name(allocation_obj, ldap_group):
     slate_project_directory.value = ldap_group_split[1]
     slate_project_directory.save()
     logger.info(
-        f'Slate Project attribute {allocation_attribute_type} was updated during sync'
+        f'Slate Project allocation {allocation_obj.pk}\'s "{allocation_attribute_type}" attribute '
+        f'was updated during sync'
     )
 
 
@@ -122,7 +123,8 @@ def sync_slate_project_ldap_group(allocation_obj, ldap_conn=None):
         allocation_ldap_group.value = ldap_group
         allocation_ldap_group.save()
         logger.info(
-            f'Slate Project LDAP group name changed from {old_ldap_group} to {ldap_group} during sync'
+            f'Slate Project allocation {allocation_obj.pk}\'s "LDAP Group" attribute changed from '
+            f'{old_ldap_group} to {ldap_group} during sync'
         )
         sync_slate_project_directory_name(allocation_obj, ldap_group)
     

--- a/coldfront/plugins/slate_project/utils.py
+++ b/coldfront/plugins/slate_project/utils.py
@@ -1227,7 +1227,7 @@ class LDAPModify:
     def get_attribute(self, attribute, gid_number):
         search_parameters = {
             'search_base': self.LDAP_BASE_DN,
-            'search_filter': ldap.filter.filter_format('(gidNumber=%s)', [gid_number]),
+            'search_filter': ldap.filter.filter_format('(gidNumber=%s)', [str(gid_number)]),
             'attributes': [attribute],
             'size_limit': 1
         }
@@ -1246,7 +1246,7 @@ class LDAPModify:
     def check_attribute_exists(self, attribute, gid_number):
         search_parameters = {
             'search_base': self.LDAP_BASE_DN,
-            'search_filter': ldap.filter.filter_format('(gidNumber=%s)', [gid_number]),
+            'search_filter': ldap.filter.filter_format('(gidNumber=%s)', [str(gid_number)]),
             'attributes': [attribute]
         }
         self.conn.search(**search_parameters)

--- a/coldfront/plugins/slate_project/utils.py
+++ b/coldfront/plugins/slate_project/utils.py
@@ -508,12 +508,11 @@ def add_user_to_slate_project_group(allocation_user_obj):
             f'LDAP: Added user {username} to the slate project group {ldap_group} in allocation '
             f'{allocation_obj.pk}'
         )
-
-    if ENABLE_LDAP_ELIGIBILITY_SERVER:
-        notifications_enabled = allocation_user_obj.allocation.project.projectuser_set.get(
-            user=allocation_user_obj.user
-        ).enable_notifications
-        check_slate_project_account(allocation_user_obj.user, notifications_enabled)
+        if ENABLE_LDAP_ELIGIBILITY_SERVER:
+            notifications_enabled = allocation_user_obj.allocation.project.projectuser_set.get(
+                user=allocation_user_obj.user
+            ).enable_notifications
+            check_slate_project_account(allocation_user_obj.user, notifications_enabled)
 
 
 def remove_slate_project_groups(allocation_obj):

--- a/coldfront/plugins/slate_project/utils.py
+++ b/coldfront/plugins/slate_project/utils.py
@@ -843,7 +843,7 @@ def import_slate_projects(limit=None, json_file_name=None, out_file_name=None):
             extra_project_information = extra_information.get(line_split[0])
             if extra_project_information is None:
                 abstract = f'Slate Project {line_split[0]}'
-                project_title = f'Imported slate project {line_split[0]}'
+                project_title = f'Slate Project {line_split[0]}'
                 allocated_quantity = None
                 start_date = None
             else:


### PR DESCRIPTION
Changes:
- Slate Project LDAP groups are now handled with their GIDS
- Slate Project import script now uses the default max managers env value
- Prevented users from renewing allocations in archived projects
- Project end dates are now updated when archived
- Created command for locking and unlocking allocations in bulk
- Created command for updating the max managers in all projects
- The word "Imported" has been removed from the title of imported projects
- Added Slate Project LDAP group name syncing
- Changed Namespace Entry attribute to Slate Project Directory attribute