### PR TITLE
Coldfront internal update

### DIFF
--- a/coldfront/core/portal/views.py
+++ b/coldfront/core/portal/views.py
@@ -83,7 +83,7 @@ def home(request):
 
         projects_with_a_slurm_account_to_list = []
         for project in project_list:
-            resources_with_slurm_accounts = project.get_list_of_resources_with_slurm_accounts()
+            resources_with_slurm_accounts = project.get_list_of_resources_with_slurm_accounts(request.user)
             if resources_with_slurm_accounts:
                 project_dict = {
                     'title': project.title,

--- a/coldfront/core/project/models.py
+++ b/coldfront/core/project/models.py
@@ -170,10 +170,12 @@ required to log onto the site at least once before they can be added.
         )
         return [manager.user.username for manager in project_managers]
     
-    def get_list_of_resources_with_slurm_accounts(self):
+    def get_list_of_resources_with_slurm_accounts(self, user):
         resources = set()
         allocations = self.allocation_set.filter(
-            status__name__in=['Active', 'Renewal Requested', ]
+            status__name__in=['Active', 'Renewal Requested', ],
+            allocationuser__user=user,
+            allocationuser__status__name='Active'
         )
         for allocation in allocations:
             resource = allocation.get_parent_resource

--- a/coldfront/plugins/advanced_search/forms.py
+++ b/coldfront/plugins/advanced_search/forms.py
@@ -223,7 +223,6 @@ class UserSearchForm(forms.Form):
 
     user__usernames = forms.CharField(
         label="Usernames",
-        max_length=100,
         required=False,
         help_text='username1,username2,...'
     )

--- a/coldfront/plugins/slate_project/signals.py
+++ b/coldfront/plugins/slate_project/signals.py
@@ -1,3 +1,5 @@
+from datetime import datetime, timedelta
+
 from django.dispatch import receiver
 
 from coldfront.core.allocation.signals import (allocation_activate_user,

--- a/coldfront/plugins/slate_project/signals.py
+++ b/coldfront/plugins/slate_project/signals.py
@@ -112,6 +112,7 @@ def sync_slate_project(sender, **kwargs):
 
     slate_project_user_objs = AllocationUser.objects.filter(
         allocation = allocation_obj,
-        status__name__in=['Active', 'Eligible', 'Disabled', 'Retired']
+        status__name__in=['Active', 'Eligible', 'Disabled', 'Retired'],
+        modified__lt = datetime.now() - timedelta(seconds=5)
     ).select_related('user', 'status', 'allocation', 'allocation__project')
     sync_slate_project_user_statuses(slate_project_user_objs)

--- a/coldfront/plugins/slate_project/utils.py
+++ b/coldfront/plugins/slate_project/utils.py
@@ -846,7 +846,7 @@ def get_slate_project_info(username):
     """
     allocation_user_objs = AllocationUser.objects.filter(
         user__username=username,
-        status__name='Active',
+        status__name__in=['Active', 'Eligible', 'Disabled', 'Retired'],
         allocation__status__name__in=['Active', 'Renewal Requested'],
         allocation__resources__name='Slate Project'
     )

--- a/coldfront/plugins/slate_project/utils.py
+++ b/coldfront/plugins/slate_project/utils.py
@@ -1426,7 +1426,11 @@ class LDAPEligibilityGroup:
             logger.error(f'LDAPEligibilityGroup: Failed to bind to LDAP server: {self.conn.result}')
 
     def add_user(self, username):
-        added = self.conn.add(self.LDAP_BASE_DN, attributes={'member': self.LDAP_ADS_NETID_FORMAT.format(username)})
+        changes = {
+            'member': [(MODIFY_ADD, [self.LDAP_ADS_NETID_FORMAT.format(username)])]
+        }
+        added = self.conn.modify(self.LDAP_BASE_DN, changes)
+
         return added, self.conn.result.get("description")
 
     def check_user_exists(self, username):


### PR DESCRIPTION
Changes:
- Fix error when adding users to the eligibility group
- Fix incorrect status showing up for users who were recently added to the eligibility group
- Remove length limit for the username field in the user search section on the advanced search page
- Fix resources users didn't have access to being listed in the slurm help text on the home page
- Add the option to include the project id to import a slate project into
- Fix slate projects not being listed for users who had the Eligible, Disabled, or Retired statuses