### PR TITLE
Coldfront internal update

### DIFF
--- a/coldfront/components/site/templates/allocation/allocation_detail.html
+++ b/coldfront/components/site/templates/allocation/allocation_detail.html
@@ -123,7 +123,7 @@ Allocation Detail
                         </span>
                       </a>
                     {% endif %}
-                  {% elif is_allowed_to_update_project and ALLOCATION_ENABLE_ALLOCATION_RENEWAL and allocation.status.name == 'Expired' and allocation.expires_in >= ALLOCATION_DAYS_TO_REVIEW_AFTER_EXPIRING|change_sign %}
+                  {% elif is_allowed_to_update_project and ALLOCATION_ENABLE_ALLOCATION_RENEWAL and allocation.status.name == 'Expired' and allocation.expires_in >= ALLOCATION_DAYS_TO_REVIEW_AFTER_EXPIRING|change_sign and not allocation.is_locked %}
                     {% if allocation.can_be_renewed %}
                       <a href="{% url 'allocation-renew' allocation.pk %}">
                         <span class="badge badge-warning"><i class="fas fa-redo-alt" aria-hidden="true"></i>

--- a/coldfront/components/site/templates/project/project_detail.html
+++ b/coldfront/components/site/templates/project/project_detail.html
@@ -343,7 +343,7 @@ Project Detail
                         </span>
                       </a>
                     {% endif %}
-                  {% elif is_allowed_to_update_project and ALLOCATION_ENABLE_ALLOCATION_RENEWAL and allocation.status.name == 'Expired' and allocation.expires_in >= ALLOCATION_DAYS_TO_REVIEW_AFTER_EXPIRING|change_sign %}
+                  {% elif is_allowed_to_update_project and ALLOCATION_ENABLE_ALLOCATION_RENEWAL and allocation.status.name == 'Expired' and allocation.expires_in >= ALLOCATION_DAYS_TO_REVIEW_AFTER_EXPIRING|change_sign and not allocation.is_locked %}
                     <a href="{% url 'allocation-renew' allocation.pk %}">
                       {% if allocation.can_be_renewed %}
                         <span class="badge badge-warning"><i class="fas fa-redo-alt" aria-hidden="true"></i>

--- a/coldfront/core/allocation/tasks.py
+++ b/coldfront/core/allocation/tasks.py
@@ -55,6 +55,7 @@ def send_expiry_emails():
             status__name='Active',
             end_date=expring_in_days,
             project__requires_review=True,
+            project__status__name__in=['Active', 'Review Pending'],
             is_locked=False
         )
         for allocation_obj in allocations_expiring_soon:

--- a/coldfront/core/allocation/tasks.py
+++ b/coldfront/core/allocation/tasks.py
@@ -148,7 +148,8 @@ def send_expiry_emails():
     for allocation_obj in Allocation.objects.filter(
         end_date=expring_in_days,
         status__name__in=['Active', ],
-        project__requires_review=True):
+        project__requires_review=True,
+        is_locked=False):
 
         expire_notification = allocation_obj.allocationattribute_set.filter(
             allocation_attribute_type__name='EXPIRE NOTIFICATION').first()

--- a/coldfront/core/allocation/views.py
+++ b/coldfront/core/allocation/views.py
@@ -2994,8 +2994,11 @@ class AllocationRenewView(LoginRequiredMixin, UserPassesTestMixin, TemplateView)
                             'Active', 'Denied', 'New', 'Billing Information Submitted', 'Paid', 'Payment Pending',
                                 'Payment Requested', 'Payment Declined', 'Renewal Requested', 'Unpaid',)):
 
-                            allocation_user_obj = active_allocation.allocationuser_set.get(
+                            allocation_user_obj = active_allocation.allocationuser_set.filter(
                                 user=user_obj)
+                            if not allocation_user_obj.exists():
+                                continue
+                            allocation_user_obj = allocation_user_obj[0]
                             allocation_user_obj.status = allocation_user_removed_status_choice
                             allocation_user_obj.save()
                             allocation_remove_user.send(


### PR DESCRIPTION
Changes:
- Changed allocation expiry emails to only go out if an allocation is in a project with a specific status
- Fixed a missing user error when a user is removed from the project during and allocation renewal
- Fixed locked allocations still showing the option to be renewed after they expire
- Changed allocation expiring emails to not be sent for locked allocations 