### PR TITLE
Coldfront internal update

### DIFF
--- a/coldfront/components/site/templates/portal/nonauthorized_home.html
+++ b/coldfront/components/site/templates/portal/nonauthorized_home.html
@@ -16,36 +16,33 @@
       <div class="card-body">
         <!-- <h3 class="card-title h5">Do not have an Account?</h3>
         <p class="card-text" style="text-align: justify;text-justify: inter-word;">{% settings_value 'ACCOUNT_CREATION_TEXT' %}</p> -->
+        <div>
+          <h2 class="card-title h2">What resources are available through RT Projects?</h2>
+          <div style="margin-left: 10px;">
+            <h3>Computing</h3>
+            <ul>
+              <li><a href="https://kb.iu.edu/d/qrtz">Quartz</a></li>
+              <li><a href="https://kb.iu.edu/d/brcc">Big Red 200</a></li>
+            </ul>
+          </div>
+          <div style="margin-left: 10px;"> 
+            <h3>Storage</h3>
+            <ul>
+              <li><a href="https://kb.iu.edu/d/aqnj">Slate-Project</a></li>
+            </ul>
+          </div>
+          <div style="margin-left: 10px;">
+            <h3>Services</h3>
+            <ul>
+              <li><a href="https://kb.iu.edu/d/bgto">Posit Connect</a></li>
+            </ul>
+          </div>
+        </div>
         <h2 class="card-title h2">What is RT Projects?</h2>
         <p class="card-text" style="text-align: justify;text-justify: inter-word;">RT Projects provides an easy platform to discover and obtain access to high performance computing systems, storage, and other research resources supported by <a href="https://rt.iu.edu/">Research Technologies</a>. </p>
         <h2 class="card-title h2">Who can use RT Projects?</h2>
         <p class="card-text" style="text-align: justify;text-justify: inter-word;">
           IU faculty, staff, and students are able to create and manage Projects that connect their collaborators and students to the resources they need. Students will need to provide their PI's username when creating a project. Creating a Project is easy&mdash; just provide a quick description detailing your research or intended coursework, request the resources you need, and list participants that also need access. Students needing these resources for a class are able to search for their course's Project and view Projects they have been added to.</p>
-        <h2 class="card-title h2">What resources are available through RT Projects?</h2>
-        <div>
-          <div class="float-left" style="margin-right: 10px;">
-          <h3>Computing</h3>
-            <ul>
-            <li><a href="https://kb.iu.edu/d/qrtz">Quartz</a></li>
-            <li><a href="https://kb.iu.edu/d/brcc">Big Red 200</a></li>
-            </ul>
-          </div>
-          <!-- <div class="float-left" style="margin-left: 10px; margin-right: 10px;"> 
-            <h6>Storage</h6>
-              <ul>
-                <li><a href="https://kb.iu.edu/d/auag">Geode-Project</a></li>
-                <li><a href="https://kb.iu.edu/d/aiyi">SDA Increased Allocation</a></li>
-                <li><a href="https://kb.iu.edu/d/aqnj">Slate-Project</a></li>
-              </ul>
-            </div>
-          <div class="float-left">
-            <h6>Services</h6>
-            <ul>
-              <li>cBioPortal</li>
-              <li><a href="https://kb.iu.edu/d/bgto">RStudioConnect</a></li>
-            </ul>
-          </div> -->
-        </div>
       </div>
     </div>
   {% include "portal/extra_app_templates.html" %}

--- a/coldfront/core/project/tasks.py
+++ b/coldfront/core/project/tasks.py
@@ -81,7 +81,7 @@ def send_expiry_emails():
 
         # Projects expiring today
         today = datetime.datetime.today()
-        for project_obj in Project.objects.filter(end_date=today, requires_review=True):
+        for project_obj in Project.objects.filter(status__name='Active', end_date=today, requires_review=True):
             project_review_url = '{}/{}/{}/{}'.format(
                 CENTER_BASE_URL.strip('/'), 'project', project_obj.pk, 'review'
             )

--- a/coldfront/core/project/views.py
+++ b/coldfront/core/project/views.py
@@ -1563,7 +1563,7 @@ class ProjectRemoveUsersView(LoginRequiredMixin, UserPassesTestMixin, TemplateVi
 
                     # get allocation to remove users from
                     allocations_to_remove_user_from = project_obj.allocation_set.filter(
-                        status__name__in=['Active', 'New', 'Renewal Requested'])
+                        status__name__in=['Active', 'New', 'Renewal Requested', 'Expired'])
                     for allocation in allocations_to_remove_user_from:
                         for allocation_user_obj in allocation.allocationuser_set.filter(user=user_obj, status__name__in=['Active', 'Inactive', 'Pending - Add', 'Pending - Remove', 'Eligible', 'Disabled', 'Retired']):
                             resource = allocation.get_parent_resource

--- a/coldfront/core/project/views.py
+++ b/coldfront/core/project/views.py
@@ -1474,7 +1474,7 @@ class ProjectRemoveUsersView(LoginRequiredMixin, UserPassesTestMixin, TemplateVi
 
     def dispatch(self, request, *args, **kwargs):
         project_obj = get_object_or_404(Project, pk=self.kwargs.get('pk'))
-        if project_obj.status.name in ['Archived', 'Denied', 'Expired', ]:
+        if project_obj.status.name in ['Archived', 'Denied', ]:
             messages.error(
                 request,
                 'You cannot remove users from a project with status "{}".'.format(project_obj.status.name)

--- a/coldfront/core/project/views.py
+++ b/coldfront/core/project/views.py
@@ -2331,10 +2331,14 @@ class ProjectReviewDenyView(LoginRequiredMixin, UserPassesTestMixin, View):
         project_obj.status = project_status_obj
 
         if project_review_obj.allocation_renewals:
-            allocation_status_choice = AllocationStatusChoice.objects.get(name="Active")
+            allocation_active_status_choice = AllocationStatusChoice.objects.get(name="Active")
+            allocation_expired_status_choice = AllocationStatusChoice.objects.get(name="Expired")
             for allocation_pk in project_review_obj.allocation_renewals.split(','):
                 allocation = Allocation.objects.get(pk=int(allocation_pk))
-                allocation.status = allocation_status_choice
+                if allocation.end_date <= datetime.datetime.now().date():
+                    allocation.status = allocation_expired_status_choice
+                else:
+                    allocation.status = allocation_active_status_choice
                 allocation.save()
 
         project_review_obj.save()

--- a/coldfront/core/publication/forms.py
+++ b/coldfront/core/publication/forms.py
@@ -36,6 +36,7 @@ class PublicationResultForm(forms.Form):
 class PublicationDeleteForm(forms.Form):
     title = forms.CharField(max_length=255, disabled=True)
     year = forms.CharField(max_length=30, disabled=True)
+    unique_id = forms.CharField(max_length=255, disabled=True)
     selected = forms.BooleanField(initial=False, required=False)
 
 

--- a/coldfront/core/publication/views.py
+++ b/coldfront/core/publication/views.py
@@ -348,7 +348,8 @@ class PublicationDeletePublicationsView(LoginRequiredMixin, UserPassesTestMixin,
 
         publications_do_delete = [
             {'title': publication.title,
-             'year': publication.year}
+             'year': publication.year,
+             'unique_id': publication.unique_id}
             for publication in project_obj.publication_set.all().order_by('-year')
         ]
 
@@ -393,7 +394,8 @@ class PublicationDeletePublicationsView(LoginRequiredMixin, UserPassesTestMixin,
                     publication_obj = Publication.objects.get(
                         project=project_obj,
                         title=publication_form_data.get('title'),
-                        year=publication_form_data.get('year')
+                        year=publication_form_data.get('year'),
+                        unique_id=publication_form_data.get('unique_id')
                     )
                     publication_obj.delete()
                     publications_deleted_count += 1

--- a/coldfront/plugins/update_user_profiles/utils.py
+++ b/coldfront/plugins/update_user_profiles/utils.py
@@ -27,7 +27,8 @@ def update_all_user_profiles():
     for user_profile in user_profiles:
         current_title = user_profile.title
         current_department = user_profile.department
-        attributes = ldap_search.search_a_user(user_profile.user.username, ['title', 'department'])
+        current_email = user_profile.user.email
+        attributes = ldap_search.search_a_user(user_profile.user.username, ['title', 'department', 'mail'])
         title = attributes.get('title')
         if title:
             title = title[0]
@@ -38,10 +39,19 @@ def update_all_user_profiles():
             department = department[0]
         else:
             department = ''
+        email = attributes.get('mail')
+        if email:
+            email = email[0]
+        else:
+            email = ''
         if title != current_title or department != current_department:
             user_profile.title = title
             user_profile.department = department
             user_profile.save()
+
+        if email != current_email:
+            user_profile.user.email = email
+            user_profile.user.save()
 
         if UPDATE_USER_PROFILES_UPDATE_STATUSES:
             if not title or title in ['Former Employee', 'Retired Staff']:


### PR DESCRIPTION
Changes:
- Fixed allocations not being set to expired if the project renewal was denied after the project's expiration date
- The update profiles task now updates emails
- The list of resources on the login page has been moved to the top of the text
- Project expiry emails are now only sent to active projects
- Fixed an error when deleting a duplicate publication
- Allowed users to be removed from expired projects and allocations