### PR TITLE
Coldfront internal update

### DIFF
--- a/coldfront/config/plugins/cas_login.py
+++ b/coldfront/config/plugins/cas_login.py
@@ -9,9 +9,11 @@ MIDDLEWARE += [
     'django_cas_ng.middleware.CASMiddleware',
 ]
 
-# INSTALLED_APPS += [
-#     'django_extensions'
-# ]
+ENABLE_DJANGO_EXTENSIONS = ENV.bool('ENABLE_DJANGO_EXTENSIONS', default=False)
+if ENABLE_DJANGO_EXTENSIONS:
+    INSTALLED_APPS += [
+        'django_extensions'
+    ]
 
 AUTHENTICATION_BACKENDS += [
     'django_cas_ng.backends.CASBackend',

--- a/coldfront/core/allocation/admin.py
+++ b/coldfront/core/allocation/admin.py
@@ -40,6 +40,9 @@ class AllocationUserInline(admin.TabularInline):
     fields = ('user', 'status', )
     raw_id_fields = ('user', )
 
+    def get_queryset(self, request):
+        return super().get_queryset(request).prefetch_related('user', 'status')
+
 
 class AllocationAttributeInline(admin.TabularInline):
     model = AllocationAttribute

--- a/coldfront/core/allocation/admin.py
+++ b/coldfront/core/allocation/admin.py
@@ -158,7 +158,13 @@ class AllocationAdmin(SimpleHistoryAdmin, ReviewGroupFilteredResourceQueryset):
             # We are adding an object
             return []
         else:
-            return super().get_inline_instances(request)
+            inline_instances = super().get_inline_instances(request)
+            allocation_user_inline = inline_instances[0]
+            if obj and obj.allocationuser_set.all().count() > 200:
+                setattr(allocation_user_inline, 'readonly_fields', ['user', 'status'])
+                setattr(allocation_user_inline, 'can_delete', False)
+                inline_instances[0] = allocation_user_inline
+            return inline_instances
 
     def save_formset(self, request, form, formset, change):
         if formset.model in [AllocationAdminNote, AllocationUserNote]:

--- a/coldfront/core/allocation/models.py
+++ b/coldfront/core/allocation/models.py
@@ -844,7 +844,7 @@ class AllocationAdminAction(TimeStampedModel):
     """
     user = models.ForeignKey(User, on_delete=models.CASCADE)
     allocation = models.ForeignKey(Allocation, on_delete=models.CASCADE)
-    action = models.CharField(max_length=128)
+    action = models.CharField(max_length=256)
 
 
 class AllocationRemovalStatusChoice(TimeStampedModel):

--- a/coldfront/core/allocation/views.py
+++ b/coldfront/core/allocation/views.py
@@ -1330,7 +1330,7 @@ class AllocationRequestListView(LoginRequiredMixin, UserPassesTestMixin, Templat
             allocation_list = Allocation.objects.filter(
                 status__name__in=['New', 'Renewal Requested', 'Paid', 'Billing Information Submitted'],
                 resources__review_groups__in=list(self.request.user.groups.all())
-            ).exclude(project__status__name__in=['Review Pending', 'Archived'])
+            ).exclude(project__status__name__in=['Review Pending', 'Archived']).distinct()
 
         context['allocation_status_active'] = AllocationStatusChoice.objects.get(name='Active')
         context['allocation_list'] = allocation_list

--- a/coldfront/core/project/admin.py
+++ b/coldfront/core/project/admin.py
@@ -295,7 +295,13 @@ class ProjectAdmin(SimpleHistoryAdmin):
             # We are adding an object
             return []
         else:
-            return super().get_inline_instances(request)
+            inline_instances = super().get_inline_instances(request)
+            project_user_inline = inline_instances[0]
+            if obj and obj.projectuser_set.all().count() > 200:
+                setattr(project_user_inline, 'readonly_fields', ['user', 'project', 'role', 'status', 'enable_notifications', ])
+                setattr(project_user_inline, 'can_delete', False)
+                inline_instances[0] = project_user_inline
+            return inline_instances
 
     def save_formset(self, request, form, formset, change):
         if formset.model in [ProjectAdminComment, ProjectUserMessage]:

--- a/coldfront/core/project/admin.py
+++ b/coldfront/core/project/admin.py
@@ -80,6 +80,9 @@ class ProjectUserInline(admin.TabularInline):
     readonly_fields = ['user', 'project', ]
     extra = 0
 
+    def get_queryset(self, request):
+        return super().get_queryset(request).prefetch_related('user', 'project', 'role', 'status')
+
 
 class ProjectAdminCommentInline(admin.TabularInline):
     model = ProjectAdminComment

--- a/coldfront/core/project/models.py
+++ b/coldfront/core/project/models.py
@@ -603,7 +603,7 @@ class ProjectAdminAction(TimeStampedModel):
     """
     user = models.ForeignKey(User, on_delete=models.CASCADE)
     project = models.ForeignKey(Project, on_delete=models.CASCADE)
-    action = models.CharField(max_length=100)
+    action = models.CharField(max_length=256)
 
 
 class ProjectDescriptionRecord(TimeStampedModel):

--- a/coldfront/plugins/ldap_user_info/utils.py
+++ b/coldfront/plugins/ldap_user_info/utils.py
@@ -73,13 +73,7 @@ class LDAPSearch:
         attributes = {}
         if self.conn.entries:
             attributes = json.loads(self.conn.entries[0].entry_to_json()).get('attributes')
-            logger.info(
-                f'LDAPSearch: Attributes {search_attributes_list} found for user {user_search_string}'
-            )
         else:
             attributes = dict.fromkeys(search_attributes_list, [''])
-            logger.info(
-                f'LDAPSearch: Attributes {search_attributes_list} not found for user {user_search_string}'
-            )
 
         return attributes

--- a/coldfront/plugins/slate_project/templates/slate_project/slate_project_info.html
+++ b/coldfront/plugins/slate_project/templates/slate_project/slate_project_info.html
@@ -11,6 +11,7 @@
             <th scope="col">Project</th>
             <th scope="col">Owner</th>
             <th scope="col">Access</th>
+            <th scope="col">Allocated Quantity</th>
           </tr>
         </thead>
         <tbody>
@@ -19,6 +20,7 @@
               <td>{{ slate_project.name }}</td>
               <td>{{ slate_project.owner }}</td>
               <td>{{ slate_project.access }}</td>
+              <td>{{ slate_project.allocated_quantity }}</td>
             </tr>
           {% endfor %}
         </tbody>

--- a/coldfront/plugins/slate_project/utils.py
+++ b/coldfront/plugins/slate_project/utils.py
@@ -1111,11 +1111,18 @@ def get_slate_project_info(username):
         if not attribute_obj.exists():
             continue
         directory = attribute_obj[0]
+
+        attribute_obj = allocation_user_obj.allocation.allocationattribute_set.filter(
+            allocation_attribute_type__name='Allocated Quantity'
+        )
+        allocated_quantity = f'{attribute_obj[0].value} TB' if attribute_obj.exists() else 'N/A'
+
         slate_projects.append(
             {
                 'name': directory.value.split('/')[-1],
                 'access': allocation_user_obj.role.name,
-                'owner': allocation_user_obj.allocation.project.pi.username
+                'owner': allocation_user_obj.allocation.project.pi.username,
+                'allocated_quantity': allocated_quantity
             }
         )
 

--- a/coldfront/plugins/slate_project/views.py
+++ b/coldfront/plugins/slate_project/views.py
@@ -221,7 +221,8 @@ class SlateProjectView:
                 "account": form_data.get('account_number', ''),
                 "sub_account": '',
                 "fiscal_officer": '',
-                "faculty_advisor": ''
+                "faculty_advisor": '',
+                "namespace_class": 'RT-PROJ'
             }
             data = parse.urlencode(data)
             try:


### PR DESCRIPTION
Changes:
- Added an env variable for enabling django_extensions
- Reduced log spam from LDAP queries
- Fixed duplicate allocations appearing if an admin was in more than one group assigned to a resource
- Increased the length of admin actions
- Fixed the resource filter on the admin page running unnecessary database queries
- Fixed the allowed max number of fields setting being surpassed when there are a lot of users in a project/allocation
- Reduced the number of database queries when listing users in a project/allocation on the admin page
- Added a column for Slate Project allocated quantities on the user profile page
- Added additional data to send to the MOU server